### PR TITLE
Allow ability scores below 8 during character creation

### DIFF
--- a/backend/models/character.py
+++ b/backend/models/character.py
@@ -44,7 +44,7 @@ class Character(Base):
     level = Column(Integer, default=1, nullable=False)
     experience_points = Column(Integer, default=0, nullable=False)
     
-    # Ability Scores (8-20 range, with racial bonuses)
+    # Ability Scores (1-20 range, with racial bonuses)
     strength = Column(Integer, nullable=False, default=10)
     dexterity = Column(Integer, nullable=False, default=10)
     constitution = Column(Integer, nullable=False, default=10)
@@ -159,12 +159,12 @@ class CharacterCreate(BaseModel):
     subclass_id: Optional[str] = None  # Optional - chosen at level 3 for most classes
     
     # Starting ability scores (before racial bonuses)
-    strength: int = Field(default=10, ge=8, le=15)
-    dexterity: int = Field(default=10, ge=8, le=15)
-    constitution: int = Field(default=10, ge=8, le=15)
-    intelligence: int = Field(default=10, ge=8, le=15)
-    wisdom: int = Field(default=10, ge=8, le=15)
-    charisma: int = Field(default=10, ge=8, le=15)
+    strength: int = Field(default=10, ge=1, le=15)
+    dexterity: int = Field(default=10, ge=1, le=15)
+    constitution: int = Field(default=10, ge=1, le=15)
+    intelligence: int = Field(default=10, ge=1, le=15)
+    wisdom: int = Field(default=10, ge=1, le=15)
+    charisma: int = Field(default=10, ge=1, le=15)
     
     # Character creation choices
     ability_scores: Optional[Dict[str, int]] = None  # Override individual scores if provided

--- a/backend/services/character_service.py
+++ b/backend/services/character_service.py
@@ -153,9 +153,9 @@ class CharacterService:
                                 abilities["constitution"] += 2
                                 abilities["wisdom"] += 1
         
-        # Ensure no ability goes above 20 or below 8
+        # Ensure ability scores do not exceed 20
         for ability in abilities:
-            abilities[ability] = max(8, min(20, abilities[ability]))
+            abilities[ability] = min(20, abilities[ability])
         
         return abilities
     

--- a/frontend/src/components/CharacterSheet.js
+++ b/frontend/src/components/CharacterSheet.js
@@ -9,7 +9,7 @@
  *   - Players allocate 15, 14, 13 to class primary stats + one choice
  *   - Fighter: (STR or DEX choice) + CON + one choice, minimums: WIS 6, CHA 6, INT 3
  *   - Rogue: DEX + (INT or CHA choice) + one choice, minimums: CON 6, STR 6, WIS 3
- *   - Unallocated stats default to 8
+ *   - Unallocated stats start at 0 and respect class minimums
  * 
  * Phase 2 - Enhancement Rolls:
  *   - Roll 4d6 drop lowest, six times in order (STR→DEX→CON→INT→WIS→CHA)
@@ -40,7 +40,7 @@ const CharacterSheet = () => {
   
   // Allocation state
   const [allocations, setAllocations] = useState({
-    str: 8, dex: 8, con: 8, int: 8, wis: 8, cha: 8
+    str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0
   });
   const [availableValues] = useState([15, 14, 13]);
   const [usedValues, setUsedValues] = useState([]);
@@ -78,7 +78,7 @@ const CharacterSheet = () => {
 
   const initializeAllocations = () => {
     const config = classConfigs[character.character_class] || classConfigs.Fighter;
-    const newAllocations = { str: 8, dex: 8, con: 8, int: 8, wis: 8, cha: 8 };
+    const newAllocations = { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 };
     
     // Apply class minimums
     Object.entries(config.minimums).forEach(([ability, value]) => {


### PR DESCRIPTION
## Summary
- Let unallocated ability scores start at 0 in the character sheet
- Remove backend floor of 8 when applying background bonuses
- Permit ability scores as low as 1 in character creation models

## Testing
- `pytest`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a477206684832b87b14b05182ce9b2