### PR TITLE
Fix save slot allocation and auto-load last character

### DIFF
--- a/core/database_indexeddb.py
+++ b/core/database_indexeddb.py
@@ -340,6 +340,7 @@ def init_indexeddb_database():
         indexeddb.create_index('monsters', 'challenge_rating', 'challenge_rating')
         indexeddb.create_index('items', 'item_type', 'item_type')
         indexeddb.create_index('items', 'rarity', 'rarity')
+        indexeddb.create_index('save_slots', 'slot_number', 'slot_number', unique=True)
         
         logger.info("IndexedDB object stores created successfully")
         

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -284,14 +284,21 @@ class MainWindow(QMainWindow):
         species_name = character_data.get('species_data', {}).get('name', 'Unknown')
         
         self.log_panel.log_system(f"Character created: {name} ({species_name} {class_name})")
-        
+
         try:
-            # Save character to database first
+            # Determine next available save slot
+            save_slots = self.game_engine.get_save_slots_sync()
+            occupied_numbers = {slot.slot_number for slot in save_slots if slot.is_occupied}
+            save_slot = 1
+            while save_slot in occupied_numbers:
+                save_slot += 1
+
+            # Save character to database
             save_character_data = self._prepare_character_for_save(character_data)
-            saved_character = self.game_engine.create_new_character_sync(save_character_data, save_slot=1)
-            
+            saved_character = self.game_engine.create_new_character_sync(save_character_data, save_slot=save_slot)
+
             # Store the last used slot for auto-loading
-            self.game_engine.settings['last_character_slot'] = 1
+            self.game_engine.settings['last_character_slot'] = save_slot
             self.game_engine.save_settings()
             
             # Load the saved character into the character sheet
@@ -304,7 +311,9 @@ class MainWindow(QMainWindow):
             
             # Provide definitive feedback that character was saved
             self.log_panel.log_info(f"✓ Character '{name}' successfully created and saved!")
-            self.log_panel.log_system(f"Saved to slot 1 - Level {saved_character.level} {species_name} {class_name}")
+            self.log_panel.log_system(
+                f"Saved to slot {save_slot} - Level {saved_character.level} {species_name} {class_name}"
+            )
             self.log_panel.log_info(f"Welcome, {name}! Your adventure begins...")
             
         except Exception as e:


### PR DESCRIPTION
## Summary
- Index save slots by slot number in the IndexedDB simulator
- Allocate next open slot when saving a new character and persist slot choice
- Log saved slot and enable auto-loading of the most recently played character

## Testing
- `python -m py_compile core/database_indexeddb.py ui/main_window.py`
- `python - <<'PY'
from core.database_indexeddb import init_indexeddb_database
from core.game_engine_indexeddb import GameEngineIndexedDB

init_indexeddb_database()
engine = GameEngineIndexedDB()

save_slots = engine.get_save_slots_sync()
occupied_numbers = {slot.slot_number for slot in save_slots if slot.is_occupied}
slot = 1
while slot in occupied_numbers:
    slot += 1
engine.create_new_character_sync({'name':'Alice','race_id':'human','class_id':'fighter','background_id':'folk_hero'}, save_slot=slot)

save_slots = engine.get_save_slots_sync()
occupied_numbers = {slot.slot_number for slot in save_slots if slot.is_occupied}
slot = 1
while slot in occupied_numbers:
    slot += 1
engine.create_new_character_sync({'name':'Bob','race_id':'human','class_id':'fighter','background_id':'folk_hero'}, save_slot=slot)

slots = engine.get_save_slots_sync()
print('Slots:', [(s.slot_number, s.character_name) for s in slots if s.is_occupied])
slots.sort(key=lambda s: s.last_played or s.created_at, reverse=True)
most_recent_slot = slots[0].slot_number
character = engine.load_character_sync(most_recent_slot)
print('Loaded:', character.name, 'from slot', most_recent_slot)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b11d4de1d8832bb62f5643d5dbb24a