### PR TITLE
Load character inventory items when loading character

### DIFF
--- a/core/game_engine_indexeddb.py
+++ b/core/game_engine_indexeddb.py
@@ -442,6 +442,41 @@ class GameEngineIndexedDB:
         """Synchronous version of load_character."""
         return asyncio.run(self.load_character(save_slot))
 
+    async def get_character_inventory(self, character_id: str) -> List[Dict[str, Any]]:
+        """Get inventory items for a character.
+
+        Args:
+            character_id: Character identifier
+
+        Returns:
+            List of inventory item dictionaries with name, type, quantity and weight
+        """
+        await self._ensure_connected()
+
+        inventory_records = await indexeddb.get_all('character_inventory')
+        items: List[Dict[str, Any]] = []
+
+        for record in inventory_records:
+            if record.get('character_id') != character_id:
+                continue
+
+            item_data = await indexeddb.get('items', record.get('item_id'))
+            if not item_data:
+                continue
+
+            items.append({
+                'name': item_data.get('name', 'Unknown Item'),
+                'type': item_data.get('item_type', ''),
+                'quantity': record.get('quantity', 1),
+                'weight': item_data.get('weight', 0)
+            })
+
+        return items
+
+    def get_character_inventory_sync(self, character_id: str) -> List[Dict[str, Any]]:
+        """Synchronous version of get_character_inventory."""
+        return asyncio.run(self.get_character_inventory(character_id))
+
     async def delete_character(self, save_slot: int) -> bool:
         """Delete a character and associated data from a save slot.
 

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -433,7 +433,8 @@ class MainWindow(QMainWindow):
             equipped_items['armor'] = {'name': character.equipment_armor}
         if character.equipment_shield and 'off_hand' not in equipped_items:
             equipped_items['off_hand'] = {'name': character.equipment_shield}
-        self.equipment_panel.load_equipment_data(equipped_items, [])
+        inventory_items = self.game_engine.get_character_inventory_sync(character.id)
+        self.equipment_panel.load_equipment_data(equipped_items, inventory_items)
 
         self.log_panel.log_info(f"Welcome back, {character.name}!")
     


### PR DESCRIPTION
## Summary
- Retrieve inventory items for a character from IndexedDB
- Populate equipment panel with stored inventory to show items and total weight

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b140568e30832ba44b5b17ce44b1b6