### PR TITLE
Add campaign-defined class visibility for character creation

### DIFF
--- a/database/migrations/010_add_campaign_available_classes.sql
+++ b/database/migrations/010_add_campaign_available_classes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE campaigns ADD COLUMN available_classes TEXT DEFAULT '[]';

--- a/database/schema/001_initial_schema.sql
+++ b/database/schema/001_initial_schema.sql
@@ -515,7 +515,8 @@ CREATE TABLE campaigns (
                     monster_type_weights TEXT,
                     difficulty_distribution TEXT,
                     rest_rules TEXT,
-                    style TEXT
+                    style TEXT,
+                    available_classes TEXT
                 );
 CREATE TABLE weapon_masteries (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -501,6 +501,16 @@ CREATE TABLE rogue_features (
     PRIMARY KEY (character_id)
 );
 
+CREATE TABLE campaigns (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    monster_type_weights TEXT,
+    difficulty_distribution TEXT,
+    rest_rules TEXT,
+    style TEXT,
+    available_classes TEXT
+);
+
 -- ================================================
 -- INDEXES FOR CLASS-SPECIFIC TABLES
 -- ================================================

--- a/encounter_pane/campaign/conan.json
+++ b/encounter_pane/campaign/conan.json
@@ -17,5 +17,14 @@
     "short_rest_duration": 1,
     "long_rest_duration": 8
   },
-  "style": "conan"
+  "style": "conan",
+  "available_classes": [
+    "Barbarian",
+    "Fighter",
+    "Rogue",
+    "Paladin",
+    "Cleric",
+    "Warlock",
+    "Wizard"
+  ]
 }

--- a/encounter_pane/campaign_frame.py
+++ b/encounter_pane/campaign_frame.py
@@ -1,14 +1,15 @@
 # === File: campaign_frame.py ===
 import json
-from typing import Dict
+from typing import Dict, List
 
 class CampaignFrame:
-    def __init__(self, name: str, monster_type_weights: Dict[str, float], difficulty_distribution: Dict[str, float], rest_rules: Dict[str, float], style: str):
+    def __init__(self, name: str, monster_type_weights: Dict[str, float], difficulty_distribution: Dict[str, float], rest_rules: Dict[str, float], style: str, available_classes: List[str] | None = None):
         self.name = name
         self.monster_type_weights = monster_type_weights
         self.difficulty_distribution = difficulty_distribution
         self.rest_rules = rest_rules
         self.style = style
+        self.available_classes = available_classes or []
 
     def to_dict(self):
         return {
@@ -16,7 +17,8 @@ class CampaignFrame:
             "monster_type_weights": self.monster_type_weights,
             "difficulty_distribution": self.difficulty_distribution,
             "rest_rules": self.rest_rules,
-            "style": self.style
+            "style": self.style,
+            "available_classes": self.available_classes
         }
 
     def save_to_file(self, path: str):

--- a/encounter_pane/encounter_generator.py
+++ b/encounter_pane/encounter_generator.py
@@ -150,6 +150,7 @@ class CampaignFrame:
         self.difficulty_distribution = data.get('difficulty_distribution', {})
         self.rest_rules = data.get('rest_rules', {})
         self.style = data.get('style', '')
+        self.available_classes = data.get('available_classes', [])
 
 
 class RandomBag:

--- a/encounter_pane/encounter_panel.py
+++ b/encounter_pane/encounter_panel.py
@@ -450,8 +450,9 @@ class EncounterPanel(QWidget):
         self.character_creation_data = {}  # Store character creation progress
         self.creation_step = 0  # Track current creation step
         
-        # Initialize encounter generator
+        # Initialize encounter generator and campaign frame
         self.encounter_generator = None
+        self.campaign_frame = None
         self._load_campaign_frame()
         
         # Track current encounter instances
@@ -2086,8 +2087,15 @@ class EncounterPanel(QWidget):
             # Get classes in display order
             cursor.execute("SELECT * FROM classes ORDER BY display_order, name")
             classes_data = cursor.fetchall()
-            
+
+            allowed = None
+            if getattr(self, 'campaign_frame', None):
+                allowed = {c.lower() for c in self.campaign_frame.available_classes}
+
             for class_row in classes_data:
+                name = class_row['name']
+                if allowed and name.lower() not in allowed:
+                    continue
                 class_id = class_row['id']
                 
                 # Get saving throw proficiencies
@@ -2875,6 +2883,7 @@ class EncounterPanel(QWidget):
                 frame_data = json.load(f)
             
             campaign_frame = CampaignFrame(frame_data)
+            self.campaign_frame = campaign_frame
             self.encounter_generator = EncounterGenerator(campaign_frame)
             
         except Exception as e:
@@ -2887,6 +2896,7 @@ class EncounterPanel(QWidget):
                 'style': 'standard'
             }
             campaign_frame = CampaignFrame(default_frame_data)
+            self.campaign_frame = campaign_frame
             self.encounter_generator = EncounterGenerator(campaign_frame)
     
     def _generate_encounter(self):


### PR DESCRIPTION
## Summary
- allow campaign frames to specify visible character classes
- filter class selection UI based on campaign configuration
- add database support for storing campaign-visible classes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3e7d66794832ba7f4655268054d2a