### PR TITLE
Implement layout variants and higher-contrast themes

### DIFF
--- a/action_cards/action_panel.py
+++ b/action_cards/action_panel.py
@@ -9,13 +9,13 @@ PyQt6 widget that provides quick access to character actions:
 - Context-sensitive action availability
 
 Designed to match ui_plan.md specifications:
-- Fixed size: 1728x300 (full width minus margins)
+- Fixed size is determined by the active layout profile
 - Horizontal card layout
 - Dark theme styling
 - Action cooldowns and availability
 """
 
-from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel, 
+from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
                             QPushButton, QFrame, QScrollArea, QButtonGroup,
                             QToolTip, QProgressBar)
 from PyQt6.QtCore import Qt, pyqtSignal, QTimer, QRect
@@ -31,6 +31,8 @@ from services.weapon_attack_service import WeaponAttackService
 from core.combat_manager import CombatManager
 from action_cards.weapon_mastery_dialog import WeaponMasteryDialog
 from ui.advantage_halo import AdvantageHalo, AdvantageResourceManager
+
+from ui.layout_profiles import BASELINE_PROFILE, LayoutProfile
 
 print("DEBUG: action_panel.py module loaded/imported at line 25")
 
@@ -132,8 +134,15 @@ class ActionPanel(QWidget):
     action_hovered = pyqtSignal(ActionType, str)  # action, description
     category_changed = pyqtSignal(ActionCategory)  # category
     
-    def __init__(self, parent: Optional[QWidget] = None):
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        layout_profile: Optional[LayoutProfile] = None,
+    ):
         super().__init__(parent)
+        self.layout_profile = layout_profile or BASELINE_PROFILE
+        self.panel_width = self.layout_profile.usable_width
+        self.panel_height = self.layout_profile.action_panel_height
         self.current_category = ActionCategory.COMBAT
         self.action_cards = {}  # ActionType -> ActionCard mapping
         self.action_cooldowns = {}  # ActionType -> remaining turns
@@ -175,8 +184,8 @@ class ActionPanel(QWidget):
         self._inspiration_offensive_active = False
         self._lucky_offensive_active = False
         
-        # Set fixed size (center + right columns only)
-        self.setFixedSize(1280, 300)  # Extended width to almost reach equipment panel
+        # Set fixed size (spans usable width inside the margins)
+        self.setFixedSize(self.panel_width, self.panel_height)
         self.setAutoFillBackground(True)  # Ensure background is filled
         
         # Initialize UI components
@@ -1271,65 +1280,78 @@ class ActionPanel(QWidget):
             return f"{damage_dice} {damage_type}"
     
     def _apply_styles(self):
-        """Apply dark theme styling to action panel components."""
-        style_sheet = """
-        ActionPanel {
-            background-color: #1a1a1a;
-        }
-        
-        QFrame#headerFrame {
-            background-color: #333333;
-            border: 1px solid #555555;
+        """Apply initial styling based on the active theme."""
+        theme_name = 'light'
+        parent = self.parent()
+        if parent and hasattr(parent, 'current_theme'):
+            theme_name = getattr(parent, 'current_theme', 'light')
+        self._apply_styles_for_theme(theme_name)
+
+    def _apply_styles_for_theme(self, theme_name: str):
+        from ui.themes import get_theme_palette
+
+        palette = get_theme_palette(theme_name)
+        style_sheet = f"""
+        ActionPanel {{
+            background-color: {palette['surface']};
+            border-top: 2px solid {palette['border']};
+        }}
+
+        QFrame#headerFrame {{
+            background-color: {palette['surface']};
+            border: 1px solid {palette['border']};
             border-radius: 4px;
-        }
-        
-        QLabel#titleLabel {
-            color: #ffffff;
+        }}
+
+        QLabel#titleLabel {{
+            color: {palette['text']};
             font-size: 16px;
             font-weight: bold;
-        }
-        
-        QPushButton#categoryButton {
-            background-color: #404040;
-            color: #cccccc;
-            border: 1px solid #666666;
+        }}
+
+        QPushButton#categoryButton {{
+            background-color: {palette['button']};
+            color: {palette['text']};
+            border: 1px solid {palette['border']};
             border-radius: 4px;
             padding: 4px 12px;
             font-size: 11px;
             font-weight: bold;
-        }
-        
-        QPushButton#categoryButton:hover {
-            background-color: #505050;
-        }
-        
-        QPushButton#categoryButton:checked {
-            background-color: #4a90e2;
-            color: #ffffff;
-            border-color: #6ab0ff;
-        }
-        
-        QScrollArea#scrollArea {
-            background-color: #1e1e1e;
-            border: 1px solid #444444;
+        }}
+
+        QPushButton#categoryButton:hover {{
+            background-color: {palette['button_hover']};
+        }}
+
+        QPushButton#categoryButton:checked {{
+            background-color: {palette['selection']};
+            color: {palette['text']};
+            border-color: {palette['accent_primary']};
+        }}
+
+        QScrollArea#scrollArea {{
+            background-color: {palette['surface']};
+            border: 1px solid {palette['border']};
             border-radius: 4px;
-        }
-        
-        QScrollBar:horizontal {
-            background-color: #2a2a2a;
+        }}
+
+        QScrollBar:horizontal {{
+            background-color: {palette['surface']};
             height: 12px;
             border-radius: 6px;
-        }
-        
-        QScrollBar::handle:horizontal {
-            background-color: #555555;
+            border: 1px solid {palette['border']};
+        }}
+
+        QScrollBar::handle:horizontal {{
+            background-color: {palette['accent_primary']};
             border-radius: 6px;
             min-width: 20px;
-        }
-        
-        QScrollBar::handle:horizontal:hover {
-            background-color: #666666;
-        }
+            border: 1px solid {palette['border']};
+        }}
+
+        QScrollBar::handle:horizontal:hover {{
+            background-color: {palette['accent_secondary']};
+        }}
         """
         self.setStyleSheet(style_sheet)
     
@@ -4488,6 +4510,7 @@ class ActionPanel(QWidget):
     
     def update_theme(self, theme_name: str):
         """Update all action cards to use the specified theme."""
+        self._apply_styles_for_theme(theme_name)
         for card in self.action_cards.values():
             card.update_theme_styles(theme_name)
     
@@ -6693,39 +6716,39 @@ class ActionCard(QWidget):
     def update_theme_styles(self, theme_name: str):
         """Update styling based on theme."""
         if theme_name == "light":
-            # Light theme colors
-            card_bg = "#d4b896"        # surface color from light theme
-            card_border = "#a0673f"    # button color from light theme
-            card_border_hover = "#5c8b7a"  # accent_tertiary from light theme
-            icon_bg = "#e8c5a0"        # background color from light theme
-            name_color = "#4a3528"     # Very dark text from light theme
-            desc_color = "#6b4d3a"     # Secondary text from light theme
-            button_bg = "#a0673f"      # button color from light theme
-            button_hover = "#b8784a"   # button_hover from light theme
-            button_pressed = "#8b5a3c" # accent_primary from light theme
+            # Light theme colors tuned to palette
+            card_bg = "#f4e5d4"        # surface color from light theme
+            card_border = "#a45f38"    # button color from light theme
+            card_border_hover = "#3f7663"  # accent_tertiary from light theme
+            icon_bg = "#f8ecdf"        # background highlight
+            name_color = "#2b211c"     # Primary text color
+            desc_color = "#4c3d35"     # Secondary text color
+            button_bg = "#a45f38"      # button color from light theme
+            button_hover = "#bb7346"   # button_hover from light theme
+            button_pressed = "#7c4f32" # accent_primary from light theme
             button_text = "#ffffff"    # White text on colored buttons
-            button_disabled_bg = "#c4a484"  # Lighter surface color
-            button_disabled_text = "#8b7355"  # Darker secondary text
-            cooldown_border = "#a0673f"
-            cooldown_bg = "#e8c5a0"
-            cooldown_chunk = "#d4956b"  # accent_quaternary from light theme
+            button_disabled_bg = "#ddc3a7"  # Lighter surface color
+            button_disabled_text = "#83644b"  # Darker secondary text
+            cooldown_border = "#a45f38"
+            cooldown_bg = "#fff9f1"
+            cooldown_chunk = "#cf8a5b"  # accent_quaternary from light theme
         else:
-            # Dark theme colors (original)
-            card_bg = "#2d2d2d"
-            card_border = "#555555"
-            card_border_hover = "#4a90e2"
-            icon_bg = "#333333"
-            name_color = "#ffffff"
-            desc_color = "#cccccc"
-            button_bg = "#4a90e2"
-            button_hover = "#6ab0ff"
-            button_pressed = "#3a80d2"
-            button_text = "#ffffff"
-            button_disabled_bg = "#555555"
-            button_disabled_text = "#888888"
-            cooldown_border = "#666666"
-            cooldown_bg = "#1a1a1a"
-            cooldown_chunk = "#ff6b6b"
+            # Dark theme colors tuned to palette
+            card_bg = "#2d2116"
+            card_border = "#4c3a2a"
+            card_border_hover = "#3d6d5a"
+            icon_bg = "#1f150d"
+            name_color = "#f2e6cf"
+            desc_color = "#d6c6ac"
+            button_bg = "#3d6d5a"
+            button_hover = "#4f846d"
+            button_pressed = "#2c5242"
+            button_text = "#f2e6cf"
+            button_disabled_bg = "#3b2b1f"
+            button_disabled_text = "#8c7b63"
+            cooldown_border = "#5b4633"
+            cooldown_bg = "#1f150d"
+            cooldown_chunk = "#8a6748"
         
         self.setStyleSheet(f"""
         ActionCard {{

--- a/character_sheet/character_panel.py
+++ b/character_sheet/character_panel.py
@@ -3,15 +3,15 @@ Character Sheet Widget - Expandable character information panel
 
 PyQt6 widget that displays character information with animation capability:
 - Character stats, abilities, and details
-- Expandable from 648px to 1296px width
+- Expandable width scales with layout profile settings
 - Smooth animation using QPropertyAnimation
 - Integration ready for GameEngine character data
 
 Designed to match ui_plan.md specifications:
-- Default size: 648x972
-- Expanded size: 1296x972  
+- Default size driven by the active layout profile
+- Expanded size doubles the profile width for detailed content
 - Animation duration: 400ms with OutCubic easing
-- Dark theme styling
+- Theme-aware styling
 """
 
 from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
@@ -23,6 +23,8 @@ from typing import Optional, Dict, Any
 from datetime import datetime
 import sqlite3
 import os
+
+from ui.layout_profiles import BASELINE_PROFILE, LayoutProfile
 
 # Import condition display widget
 try:
@@ -51,16 +53,24 @@ class CharacterPanel(QWidget):
     expansion_changed = pyqtSignal(bool)  # expanded state
     character_action_requested = pyqtSignal(str)  # action name
     
-    def __init__(self, parent: Optional[QWidget] = None):
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        layout_profile: Optional[LayoutProfile] = None,
+    ):
         super().__init__(parent)
+        self.layout_profile = layout_profile or BASELINE_PROFILE
+        self.base_width = self.layout_profile.character_panel_width
+        self.expanded_width = self.layout_profile.character_panel_max_width
+        self.panel_height = self.layout_profile.character_panel_height
         self.expanded = False
         self.animation = None
         self.character_data = None
-        
+
         # Set initial size (fits between menu and action cards)
-        self.setMinimumSize(648, 570)  # Use minimum size instead of fixed
-        self.setMaximumSize(1296, 570)  # Allow expansion to double width
-        self.resize(648, 570)  # Set initial size
+        self.setMinimumSize(self.base_width, self.panel_height)
+        self.setMaximumSize(self.expanded_width, self.panel_height)
+        self.resize(self.base_width, self.panel_height)
         self._setup_ui()
         self._apply_styles()
     
@@ -73,7 +83,7 @@ class CharacterPanel(QWidget):
         
         # Basic character panel (always visible)
         self.basic_panel = QWidget()
-        self.basic_panel.setFixedWidth(648)
+        self.basic_panel.setFixedWidth(self.base_width)
         self.basic_layout = QVBoxLayout(self.basic_panel)
         self.basic_layout.setContentsMargins(0, 0, 0, 0)
         self.basic_layout.setSpacing(0)
@@ -134,16 +144,10 @@ class CharacterPanel(QWidget):
         # Apply styling directly to override global theme
         self.expand_btn.setStyleSheet("""
             QPushButton {
-                background-color: #404040;
-                color: #ffffff;
-                border: 1px solid #666666;
-                border-radius: 3px;
-                padding: 4px 8px;
                 font-size: 10px;
                 font-weight: bold;
-            }
-            QPushButton:hover {
-                background-color: #505050;
+                padding: 4px 8px;
+                border-radius: 3px;
             }
         """)
         header_layout.addWidget(self.expand_btn)
@@ -1269,18 +1273,18 @@ class CharacterPanel(QWidget):
         
         if self.expanded:
             # EXPAND: Show detail panel and resize main widget
-            self.detail_panel.setMinimumWidth(648)
-            self.detail_panel.setMaximumWidth(648)
-            self.setMinimumSize(1296, 570)
-            self.setMaximumSize(1296, 570)
+            self.detail_panel.setMinimumWidth(self.base_width)
+            self.detail_panel.setMaximumWidth(self.base_width)
+            self.setMinimumSize(self.expanded_width, self.panel_height)
+            self.setMaximumSize(self.expanded_width, self.panel_height)
             self.expand_btn.setText("▲ Collapse")
             self.raise_()  # Bring to front to cover encounter pane
         else:
             # COLLAPSE: Hide detail panel and resize main widget
             self.detail_panel.setMinimumWidth(0)
             self.detail_panel.setMaximumWidth(0)
-            self.setMinimumSize(648, 570)
-            self.setMaximumSize(1296, 570)  # Allow future expansion
+            self.setMinimumSize(self.base_width, self.panel_height)
+            self.setMaximumSize(self.expanded_width, self.panel_height)  # Allow future expansion
             self.expand_btn.setText("▼ Expand")
         
         # Force immediate layout update

--- a/docs/UI_LAYOUT_VARIANT_PLAN.md
+++ b/docs/UI_LAYOUT_VARIANT_PLAN.md
@@ -1,0 +1,90 @@
+# UI Layout Variant Implementation Plan
+
+## Objectives
+- Reduce the apparent frame/margin around the fixed-layout desktop UI while keeping the 1920×1080 minimum window size intact.【F:ui/main_window.py†L41-L103】
+- Rebalance horizontal space: shrink the character sheet and log panels, and invest the recovered width in the encounter panel.【F:ui/main_window.py†L80-L103】【F:character_sheet/character_panel.py†L54-L92】【F:log/log_panel.py†L50-L135】
+- Flatten the action panel so it consumes less vertical space while continuing to span the gameplay columns.【F:ui/main_window.py†L100-L104】【F:action_cards/action_panel.py†L135-L190】
+- Increase text/background contrast by darkening foreground text and brightening the light-theme surfaces (and mirroring the idea for the dark theme) without breaking existing theme plumbing.【F:ui/themes.py†L10-L200】
+- Produce two side-by-side variants of the UI ("10%" and "20%" adjustments) that can be launched as independent builds for comparison, without destabilizing the existing baseline.
+
+## Baseline Snapshot (for reference)
+| Component | Current Metric | Source |
+| --- | --- | --- |
+| Window minimum size | 1920×1080 | `MainWindow.__init__`【F:ui/main_window.py†L41-L60】 |
+| Layout margins | 96 px left/right, 54 px top/bottom (≈5%) | `MainWindow._setup_ui`【F:ui/main_window.py†L66-L93】 |
+| Character panel width | 648 px minimum (expandable to 1296 px) | `CharacterPanel.__init__`【F:character_sheet/character_panel.py†L54-L92】 |
+| Encounter panel width | 648 px | `MainWindow._setup_ui` positioning【F:ui/main_window.py†L85-L93】 |
+| Log panel size | 432×486 px | `LogPanel.__init__`【F:log/log_panel.py†L50-L135】 |
+| Equipment panel size | 432×486 px | `EquipmentPanel.__init__`【F:equipment_layout/equipment_panel.py†L43-L124】 |
+| Action panel size/placement | 1280×300 px, anchored at bottom margin | `ActionPanel.__init__` & `MainWindow._setup_ui`【F:action_cards/action_panel.py†L135-L190】【F:ui/main_window.py†L100-L104】 |
+| Theme palette | Light & dark dictionaries with shared stylesheet builder | `ui/themes.py`【F:ui/themes.py†L10-L200】 |
+
+## Variant Layout Targets
+The variant percentages express how much the left (character) and right (log) panels shrink relative to baseline widths; the encounter panel receives the freed horizontal pixels. Margins scale by the same percentage to visually tighten the frame, and the action bar height follows suit.
+
+### Calculated Metrics
+| Element | Baseline | Variant 10% | Variant 20% |
+| --- | --- | --- | --- |
+| Horizontal margin | 96 px | 86 px (≈−10%) | 77 px (≈−20%) |
+| Vertical margin | 54 px | 49 px (≈−10%) | 43 px (≈−20%) |
+| Character panel width | 648 px | 583 px | 520 px |
+| Encounter panel width | 648 px | 756 px | 862 px |
+| Log panel width | 432 px | 389 px | 346 px |
+| Equipment panel width | 432 px (unchanged) | 389 px (to match log) | 346 px (to match log) |
+| Action panel height | 300 px | 270 px | 240 px |
+| Action panel width | 1728 px usable span | 1728 px usable span (keep full width) | 1728 px usable span |
+
+_Notes_
+- Character and log widths are rounded to the nearest whole pixel after scaling; encounter width is recomputed so all columns continue to consume exactly the 1728 px usable width (1920 minus horizontal margins).
+- Equipment panel should mirror the log panel width so the right column remains vertically aligned.
+- Action panel width should be stretched to the full usable width (rather than the hard-coded 1280 px) to remove the current inset and stay consistent across variants.
+
+### Placement Offsets
+For deterministic positioning inside `MainWindow._setup_ui`, update the `move(...)` coordinates to use cumulative sums driven by each variant's constants.
+
+| Element | Variant 10% (x, y) | Variant 20% (x, y) |
+| --- | --- | --- |
+| Menu origin | (86, 49) | (77, 43) |
+| Character panel origin | (86, 139) — preserves 90 px gap below menu | (77, 133) |
+| Encounter panel origin | (669, 49) | (597, 43) |
+| Log panel origin | (1425, 49) | (1459, 43) |
+| Equipment panel origin | (1425, 49 + log height) | (1459, 43 + log height) |
+| Action panel origin | (86, 761) | (77, 797) |
+| Theme toggle button | align 10 px inset from right column edge (x = log_x + log_width − 100) | same pattern |
+
+## Implementation Steps
+1. **Introduce layout profiles**
+   - Create `ui/layout_profiles.py` (or similar) containing dataclasses for `baseline`, `variant_10`, and `variant_20` with all measurements above.
+   - Refactor `MainWindow` to accept a profile object so positioning math reads from a single source of truth.
+
+2. **Duplicate launchers for side-by-side builds**
+   - Add lightweight entry scripts (e.g., `main_variant10.py`, `main_variant20.py`) that instantiate `MainWindow(profile=VARIANT_10)` and `MainWindow(profile=VARIANT_20)` respectively while keeping the existing `main.py` wired to the baseline profile.
+   - Adjust packaging or deployment scripts to emit separate executables/folders per profile as needed.
+
+3. **Panel-specific adjustments**
+   - Update constructor widths/heights in `CharacterPanel`, `LogPanel`, `EquipmentPanel`, and `ActionPanel` to consume the profile data instead of hard-coded numbers so each variant scales automatically.【F:character_sheet/character_panel.py†L54-L149】【F:log/log_panel.py†L50-L158】【F:equipment_layout/equipment_panel.py†L63-L124】【F:action_cards/action_panel.py†L135-L190】
+   - Ensure expandable widths (e.g., character/equipment panel animations) respect new maximums by scaling them relative to the base width (e.g., double the profile width).
+   - Revisit scroll areas and layouts for any assumptions about exact pixel counts (e.g., hard-coded spacers) to prevent clipping after resizing.
+
+4. **Action panel flattening**
+   - Replace the fixed 1280 px width with the usable width from the profile and drop the hard-coded `move(...)` value to center the panel.【F:action_cards/action_panel.py†L178-L190】
+   - Review child layouts to ensure the reduced height still fits header controls and card rows; adjust padding if necessary.
+
+5. **Contrast enhancements**
+   - Update `LIGHT_THEME` and `DARK_THEME` dictionaries with higher-contrast values (e.g., lighten `background`/`surface` by 3–5% luminance and darken `text` by ~10%) and tweak `border` colors to maintain separation.【F:ui/themes.py†L10-L200】
+   - Audit widgets with bespoke stylesheets (notably the character/equipment expand buttons and the log panel styling) so they derive colors from the updated palette rather than hard-coded dark grays that would clash with brighter surfaces.【F:character_sheet/character_panel.py†L124-L149】【F:log/log_panel.py†L137-L158】【F:equipment_layout/equipment_panel.py†L101-L113】
+   - Validate theme toggle logic still flips button labels/icons appropriately after palette changes.【F:ui/main_window.py†L106-L113】
+
+6. **Testing & QA**
+   - Manual smoke-test all three profiles (baseline + two variants) to verify widget alignment, clickable regions, and lack of overlap at 1920×1080.
+   - Run the existing automated test suite to ensure no regressions in business logic.
+   - Visually inspect light and dark themes under each profile to confirm the desired contrast gain.
+
+## Deployment & Comparison Workflow
+- Package or zip each profile-specific entry script into its own distribution folder (e.g., `TaleKeeper-UI10/`, `TaleKeeper-UI20/`) so stakeholders can open them side-by-side.
+- Document in release notes that the builds differ only by layout profile to aid QA comparisons.
+
+## Open Questions / Risks
+- Hard-coded pixel math scattered across nested widgets may require additional refactoring if animation or positioning relies on the old dimensions.
+- Theme overrides embedded in individual widgets could dilute the intended contrast boost unless normalized during implementation.
+- Any persistence of window geometry or splitter settings should be checked to ensure they do not override the new defaults when profiles switch.

--- a/encounter_pane/encounter_panel.py
+++ b/encounter_pane/encounter_panel.py
@@ -8,14 +8,14 @@ PyQt6 widget that serves as the main content display area:
 - Combat interfaces
 - Exploration content
 
-Designed to match ui_plan.md specifications:
-- Fixed size: 648x972 (center panel)
+- Designed to match ui_plan.md specifications:
+- Layout dimensions follow the active profile for center panel sizing
 - Flexible content display
 - Dark theme styling
 - Integration ready for GameEngine encounter data
 """
 
-from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel, 
+from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
                             QPushButton, QFrame, QTextEdit, QScrollArea,
                             QTabWidget, QListWidget, QListWidgetItem,
                             QSplitter, QGroupBox, QGridLayout, QComboBox,
@@ -42,6 +42,7 @@ from dataclasses import dataclass, field
 from typing import Any, Optional, Dict
 from datetime import datetime
 
+from ui.layout_profiles import BASELINE_PROFILE, LayoutProfile
 
 def sync_hit_dice_with_level(character):
     """Ensure hit dice maximum matches level and add only new dice."""
@@ -489,8 +490,15 @@ class EncounterPanel(QWidget):
     character_created = pyqtSignal(dict)  # Emitted when character creation is complete
     monster_selected = pyqtSignal(str)  # Emitted when monster card is selected (instance_id)
     
-    def __init__(self, parent: Optional[QWidget] = None):
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        layout_profile: Optional[LayoutProfile] = None,
+    ):
         super().__init__(parent)
+        self.layout_profile = layout_profile or BASELINE_PROFILE
+        self.panel_width = self.layout_profile.encounter_panel_width
+        self.panel_height = self.layout_profile.encounter_panel_height
         self.current_encounter = None
         self.encounter_mode = "exploration"  # exploration, encounter, combat, character_creation
         self.character_creation_data = {}  # Store character creation progress
@@ -523,7 +531,7 @@ class EncounterPanel(QWidget):
         self.stealth_dc = 0
         
         # Set fixed size (fits above action cards)
-        self.setFixedSize(648, 672)  # 726 - 54 = 672px available space
+        self.setFixedSize(self.panel_width, self.panel_height)
         self._setup_ui()
         self._apply_styles()
         self._show_initial_random_encounter()

--- a/equipment_layout/equipment_panel.py
+++ b/equipment_layout/equipment_panel.py
@@ -4,18 +4,18 @@ Equipment Panel Widget - Expandable inventory and equipment display
 PyQt6 widget that manages character equipment and inventory:
 - Equipment slots (armor, weapons, accessories)
 - Inventory grid with item management
-- Expandable from 432px to 1080px width
+- Expandable width scales with layout profile settings
 - Drag & drop item management
 - Item tooltips and details
 
 Designed to match ui_plan.md specifications:
-- Default size: 432x486
-- Expanded size: 1080x486
+- Default size follows the active layout profile
+- Expanded size reaches across the encounter column
 - Animation duration: 400ms with OutCubic easing
 - Dark theme styling
 """
 
-from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel, 
+from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
                             QPushButton, QFrame, QScrollArea, QGridLayout,
                             QListWidget, QListWidgetItem, QTabWidget,
                             QGroupBox, QProgressBar, QSpinBox)
@@ -24,6 +24,8 @@ from PyQt6.QtGui import QDragEnterEvent, QDropEvent, QDrag, QPixmap, QPainter, Q
 from typing import Optional, Dict, Any, List
 from enum import Enum
 from services.equipment import equipment_service
+
+from ui.layout_profiles import BASELINE_PROFILE, LayoutProfile
 
 
 class EquipmentSlot(Enum):
@@ -60,8 +62,19 @@ class EquipmentPanel(QWidget):
     inventory_changed = pyqtSignal()
     ac_changed = pyqtSignal(int)  # new AC value
     
-    def __init__(self, parent: Optional[QWidget] = None):
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        layout_profile: Optional[LayoutProfile] = None,
+    ):
         super().__init__(parent)
+        self.layout_profile = layout_profile or BASELINE_PROFILE
+        self.panel_width = self.layout_profile.equipment_panel_width
+        self.panel_height = self.layout_profile.equipment_panel_height
+        self.expanded_width = (
+            self.panel_width + self.layout_profile.encounter_panel_width
+        )
+        self.toggle_height = max(1, self.panel_height - 14)
         self.expanded = False
         self.animation = None
         self.equipped_items = {}  # slot -> item mapping
@@ -79,7 +92,7 @@ class EquipmentPanel(QWidget):
         self.item_effects = ItemEffectsService()
 
         # Set initial size (extends to bottom of window)
-        self.setFixedSize(432, 486)
+        self.setFixedSize(self.panel_width, self.panel_height)
         self._setup_ui()
         self._apply_styles()
     
@@ -273,172 +286,12 @@ class EquipmentPanel(QWidget):
             self.slots_layout.addWidget(slot_widget, row, col)
     
     def _apply_styles(self):
-        """Apply dark theme styling to equipment panel components."""
-        style_sheet = """
-        EquipmentPanel {
-            background-color: #222222;
-            border: 2px solid #555555;
-            border-radius: 8px;
-        }
-        
-        QFrame#headerFrame {
-            background-color: #2a2a2a;
-            border: 1px solid #444444;
-            border-radius: 4px;
-        }
-        
-        QFrame#attacksFrame {
-            background-color: #252525;
-            border: 1px solid #444444;
-            border-radius: 4px;
-        }
-        
-        QLabel#attackValue {
-            color: #4a90e2;
-            font-size: 11px;
-            font-weight: bold;
-        }
-        
-        QFrame#equipmentSlotsFrame {
-            background-color: #1e1e1e;
-            border: 1px solid #444444;
-            border-radius: 4px;
-        }
-        
-        QLabel#titleLabel {
-            color: #ffffff;
-            font-size: 14px;
-            font-weight: bold;
-        }
-        
-        QLabel#statValue {
-            color: #4a90e2;
-            font-size: 12px;
-            font-weight: bold;
-        }
-        
-        QLabel#weightLabel {
-            color: #cccccc;
-            font-size: 11px;
-            min-width: 50px;
-        }
-        
-        QPushButton#expandButton {
-            background-color: #404040;
-            color: #ffffff;
-            border: 1px solid #666666;
-            border-radius: 3px;
-            padding: 4px 8px;
-            font-weight: bold;
-            font-size: 10px;
-        }
-        
-        QPushButton#expandButton:hover {
-            background-color: #505050;
-        }
-        
-        QPushButton#smallButton {
-            background-color: #404040;
-            color: #ffffff;
-            border: 1px solid #666666;
-            border-radius: 3px;
-            padding: 4px 8px;
-            font-size: 10px;
-            font-weight: bold;
-            min-width: 40px;
-        }
-        
-        QPushButton#smallButton:hover {
-            background-color: #505050;
-        }
-        
-        QPushButton#smallButton:pressed {
-            background-color: #303030;
-        }
-        
-        QTabWidget#contentTabs {
-            background-color: transparent;
-        }
-        
-        QTabWidget#contentTabs::pane {
-            border: 1px solid #444444;
-            border-radius: 4px;
-            background-color: #1e1e1e;
-        }
-        
-        QTabBar::tab {
-            background-color: #2a2a2a;
-            color: #cccccc;
-            border: 1px solid #444444;
-            border-bottom: none;
-            border-radius: 3px 3px 0px 0px;
-            padding: 4px 8px;
-            margin: 1px;
-            font-size: 10px;
-        }
-        
-        QTabBar::tab:selected {
-            background-color: #1e1e1e;
-            color: #ffffff;
-            border-bottom: 1px solid #1e1e1e;
-        }
-        
-        QTabBar::tab:hover {
-            background-color: #3a3a3a;
-        }
-        
-        QListWidget#inventoryList {
-            background-color: #1a1a1a;
-            color: #ffffff;
-            border: 1px solid #555555;
-            border-radius: 4px;
-            alternate-background-color: #222222;
-        }
-        
-        QListWidget#inventoryList::item {
-            padding: 4px;
-            border-bottom: 1px solid #333333;
-        }
-        
-        QListWidget#inventoryList::item:selected {
-            background-color: #4a90e2;
-            color: #ffffff;
-        }
-        
-        QListWidget#inventoryList::item:hover {
-            background-color: #2a2a2a;
-        }
-        
-        QProgressBar#weightBar {
-            border: 1px solid #666666;
-            border-radius: 3px;
-            text-align: center;
-            background-color: #1a1a1a;
-            height: 16px;
-        }
-        
-        QProgressBar#weightBar::chunk {
-            background-color: #4a9;
-            border-radius: 2px;
-        }
-        
-        QScrollBar:vertical {
-            background-color: #2a2a2a;
-            width: 10px;
-            border-radius: 5px;
-        }
-        
-        QScrollBar::handle:vertical {
-            background-color: #555555;
-            border-radius: 5px;
-            min-height: 15px;
-        }
-        
-        QScrollBar::handle:vertical:hover {
-            background-color: #666666;
-        }
-        """
-        self.setStyleSheet(style_sheet)
+        """Apply initial styling using the active theme palette."""
+        theme_name = 'light'
+        parent = self.parent()
+        if parent and hasattr(parent, 'current_theme'):
+            theme_name = getattr(parent, 'current_theme', 'light')
+        self.update_theme(theme_name)
     
     def update_theme(self, theme_name: str):
         """Update styling based on theme."""
@@ -569,27 +422,27 @@ class EquipmentPanel(QWidget):
         # Toggle expansion state
         self.expanded = not self.expanded
         
+        width_delta = self.expanded_width - self.panel_width
+
         if self.expanded:
             # EXPAND: Move left and resize to cover encounter pane
             current_pos = self.pos()
-            # Move left by the difference in width (1080 - 432 = 648)
-            new_x = current_pos.x() - (1080 - 432)
+            new_x = current_pos.x() - width_delta
             self.move(new_x, current_pos.y())
-            
-            self.setFixedSize(1080, 472)
+
+            self.setFixedSize(self.expanded_width, self.toggle_height)
             self.expand_btn.setText("▲ Collapse")
             self.raise_()  # Bring to front to cover encounter pane
-            
+
             # Switch to expanded layout
             self._switch_to_expanded_layout()
         else:
             # COLLAPSE: Move right and resize back to normal position
             current_pos = self.pos()
-            # Move right by the difference in width (1080 - 432 = 648)
-            new_x = current_pos.x() + (1080 - 432)
+            new_x = current_pos.x() + width_delta
             self.move(new_x, current_pos.y())
-            
-            self.setFixedSize(432, 472)
+
+            self.setFixedSize(self.panel_width, self.toggle_height)
             self.expand_btn.setText("▼ Expand")
             
             # Switch to compact layout

--- a/log/log_panel.py
+++ b/log/log_panel.py
@@ -24,6 +24,8 @@ from enum import Enum
 import json
 from datetime import datetime
 
+from ui.layout_profiles import BASELINE_PROFILE, LayoutProfile
+
 
 class LogLevel(Enum):
     """Message severity levels."""
@@ -47,14 +49,22 @@ class LogPanel(QWidget):
     log_exported = pyqtSignal(str)  # file path
     filter_changed = pyqtSignal(list)  # enabled levels
     
-    def __init__(self, parent: Optional[QWidget] = None):
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        layout_profile: Optional[LayoutProfile] = None,
+    ):
         super().__init__(parent)
+        self.layout_profile = layout_profile or BASELINE_PROFILE
         self.log_entries = []
         self.enabled_levels = set(LogLevel)  # All levels enabled by default
         self.max_entries = 1000  # Limit to prevent memory issues
-        
+
         # Set fixed size
-        self.setFixedSize(432, 486)
+        self.setFixedSize(
+            self.layout_profile.log_panel_width,
+            self.layout_profile.log_panel_height,
+        )
         self._setup_ui()
         self._apply_styles()
         
@@ -135,126 +145,12 @@ class LogPanel(QWidget):
         self.main_layout.addWidget(self.controls_frame)
     
     def _apply_styles(self):
-        """Apply dark theme styling to log panel components."""
-        style_sheet = """
-        LogPanel {
-            background-color: #181818;
-            border: 2px solid #555555;
-            border-radius: 8px;
-        }
-        
-        QFrame#headerFrame {
-            background-color: #222222;
-            border: 1px solid #444444;
-            border-radius: 4px;
-        }
-        
-        QFrame#controlsFrame {
-            background-color: #222222;
-            border: 1px solid #444444;
-            border-radius: 4px;
-        }
-        
-        QLabel#titleLabel {
-            color: #ffffff;
-            font-size: 14px;
-            font-weight: bold;
-        }
-        
-        QTextEdit#logText {
-            background-color: #151515;
-            color: #ffffff;
-            border: 1px solid #444444;
-            border-radius: 4px;
-            padding: 5px;
-            font-family: 'Consolas', 'Monaco', monospace;
-            font-size: 11px;
-        }
-        
-        QComboBox#filterCombo {
-            background-color: #2a2a2a;
-            color: #ffffff;
-            border: 1px solid #555555;
-            border-radius: 3px;
-            padding: 3px 6px;
-            min-width: 100px;
-        }
-        
-        QComboBox#filterCombo::drop-down {
-            border: none;
-        }
-        
-        QComboBox#filterCombo::down-arrow {
-            width: 12px;
-            height: 12px;
-        }
-        
-        QComboBox#filterCombo QAbstractItemView {
-            background-color: #2a2a2a;
-            color: #ffffff;
-            border: 1px solid #555555;
-            selection-background-color: #4a90e2;
-        }
-        
-        QCheckBox#autoScrollCheckBox {
-            color: #ffffff;
-            font-size: 11px;
-        }
-        
-        QCheckBox#autoScrollCheckBox::indicator {
-            width: 16px;
-            height: 16px;
-            background-color: #2a2a2a;
-            border: 1px solid #555555;
-            border-radius: 3px;
-        }
-        
-        QCheckBox#autoScrollCheckBox::indicator:checked {
-            background-color: #4a90e2;
-            border-color: #4a90e2;
-        }
-        
-        QPushButton#smallButton {
-            background-color: #404040;
-            color: #ffffff;
-            border: 1px solid #666666;
-            border-radius: 3px;
-            padding: 4px 8px;
-            font-size: 10px;
-            font-weight: bold;
-            min-width: 50px;
-        }
-        
-        QPushButton#smallButton:hover {
-            background-color: #505050;
-        }
-        
-        QPushButton#smallButton:pressed {
-            background-color: #303030;
-        }
-        
-        QScrollBar:vertical {
-            background-color: #2a2a2a;
-            width: 12px;
-            border-radius: 6px;
-        }
-        
-        QScrollBar::handle:vertical {
-            background-color: #555555;
-            border-radius: 6px;
-            min-height: 20px;
-        }
-        
-        QScrollBar::handle:vertical:hover {
-            background-color: #666666;
-        }
-        
-        QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
-            border: none;
-            background: none;
-        }
-        """
-        self.setStyleSheet(style_sheet)
+        """Apply initial styling based on the active theme."""
+        theme_name = 'light'
+        parent = self.parent()
+        if parent and hasattr(parent, 'current_theme'):
+            theme_name = getattr(parent, 'current_theme', 'light')
+        self.update_theme(theme_name)
     
     def update_theme(self, theme_name: str):
         """Update styling based on theme."""

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ from PyQt6.QtGui import QFontDatabase, QFont
 
 from core.game_engine_sqlite import GameEngineSQLite
 from ui.main_window import MainWindow
+from ui.layout_profiles import BASELINE_PROFILE, LayoutProfile
 
 
 def setup_logging():
@@ -47,7 +48,7 @@ def setup_logging():
     )
 
 
-def main():
+def main(layout_profile: LayoutProfile | None = None):
     """Main application entry point."""
     try:
         # Setup logging
@@ -107,7 +108,8 @@ def main():
         game_engine = GameEngineSQLite()
         
         # Create main application window
-        window = MainWindow()
+        profile = layout_profile or BASELINE_PROFILE
+        window = MainWindow(layout_profile=profile)
         window.setWindowTitle("TaleKeeper - D&D 2024 Adventure")
         window.show()
         

--- a/main_variant10.py
+++ b/main_variant10.py
@@ -1,0 +1,10 @@
+"""Entry point for TaleKeeper with the 10% layout variant."""
+
+from __future__ import annotations
+
+from main import main
+from ui.layout_profiles import VARIANT_10_PROFILE
+
+
+if __name__ == "__main__":
+    main(layout_profile=VARIANT_10_PROFILE)

--- a/main_variant20.py
+++ b/main_variant20.py
@@ -1,0 +1,10 @@
+"""Entry point for TaleKeeper with the 20% layout variant."""
+
+from __future__ import annotations
+
+from main import main
+from ui.layout_profiles import VARIANT_20_PROFILE
+
+
+if __name__ == "__main__":
+    main(layout_profile=VARIANT_20_PROFILE)

--- a/ui/layout_profiles.py
+++ b/ui/layout_profiles.py
@@ -1,0 +1,86 @@
+"""Layout profiles for TaleKeeper UI variants."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LayoutProfile:
+    """Pixel measurements that describe the fixed layout geometry."""
+
+    name: str
+    horizontal_margin: int
+    vertical_margin: int
+    character_panel_width: int
+    encounter_panel_width: int
+    log_panel_width: int
+    action_panel_height: int
+    min_window_width: int = 1920
+    min_window_height: int = 1080
+    character_panel_height: int = 570
+    log_panel_height: int = 486
+    equipment_panel_height: int = 486
+    menu_character_gap: int = 90
+    theme_toggle_inset: int = 100
+    theme_toggle_height: int = 30
+    theme_toggle_width: int = 90
+
+    @property
+    def usable_width(self) -> int:
+        """Horizontal span inside the left/right margins."""
+
+        return self.min_window_width - (self.horizontal_margin * 2)
+
+    @property
+    def character_panel_max_width(self) -> int:
+        """Expanded width for animated character sheet."""
+
+        return self.character_panel_width * 2
+
+    @property
+    def encounter_panel_height(self) -> int:
+        """Height for the encounter column above the action panel."""
+
+        return (
+            self.min_window_height
+            - (self.vertical_margin * 2)
+            - self.action_panel_height
+        )
+
+    @property
+    def equipment_panel_width(self) -> int:
+        """Right column equipment width matches the log width."""
+
+        return self.log_panel_width
+
+
+BASELINE_PROFILE = LayoutProfile(
+    name="baseline",
+    horizontal_margin=96,
+    vertical_margin=54,
+    character_panel_width=648,
+    encounter_panel_width=648,
+    log_panel_width=432,
+    action_panel_height=300,
+)
+
+VARIANT_10_PROFILE = LayoutProfile(
+    name="variant_10",
+    horizontal_margin=86,
+    vertical_margin=49,
+    character_panel_width=583,
+    encounter_panel_width=756,
+    log_panel_width=389,
+    action_panel_height=270,
+)
+
+VARIANT_20_PROFILE = LayoutProfile(
+    name="variant_20",
+    horizontal_margin=77,
+    vertical_margin=43,
+    character_panel_width=520,
+    encounter_panel_width=862,
+    log_panel_width=346,
+    action_panel_height=240,
+)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -28,6 +28,10 @@ from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QAction, QKeySequence
 
 from ui.themes import build_stylesheet, get_theme_palette
+from ui.layout_profiles import (
+    BASELINE_PROFILE,
+    LayoutProfile,
+)
 from menu.game_menu import GameMenu
 from character_sheet.character_panel import CharacterPanel
 from encounter_pane.encounter_panel import EncounterPanel
@@ -38,10 +42,14 @@ from core.game_engine_sqlite import GameEngineSQLite
 
 
 class MainWindow(QMainWindow):
-    def __init__(self):
+    def __init__(self, layout_profile: LayoutProfile | None = None):
         super().__init__()
+        self.layout_profile = layout_profile or BASELINE_PROFILE
         self.setWindowTitle("TaleKeeper - D&D 2024 Adventure")
-        self.setMinimumSize(1920, 1080)
+        self.setMinimumSize(
+            self.layout_profile.min_window_width,
+            self.layout_profile.min_window_height,
+        )
         
         # Initialize game engine
         self.game_engine = GameEngineSQLite()
@@ -66,46 +74,64 @@ class MainWindow(QMainWindow):
     def _setup_ui(self):
         """Setup fixed position UI layout - no splitters, no animations"""
         
-        # 5% margins: 96px on each side, 54px top/bottom
-        # Usable area: 1728x972
-        
+        profile = self.layout_profile
+
         # === FIXED POSITION WIDGETS ===
-        
+
         # Menu (top left)
         self.menu = GameMenu(self)
-        self.menu.move(96, 54)  # Top left with 5% margin
+        self.menu.move(profile.horizontal_margin, profile.vertical_margin)
         self.menu.show()
         self.menu.raise_()
-        
-        # Character sheet (below menu, left column)  
-        self.character_sheet = CharacterPanel(self)
-        self.character_sheet.move(96, 54 + 90)  # Below menu, moved up more to reduce gap
+
+        # Character sheet (below menu, left column)
+        self.character_sheet = CharacterPanel(self, layout_profile=profile)
+        self.character_sheet.move(
+            profile.horizontal_margin,
+            profile.vertical_margin + profile.menu_character_gap,
+        )
         self.character_sheet.show()
-        
+
         # Encounter pane (center, full height)
-        self.encounter_pane = EncounterPanel(self) 
-        self.encounter_pane.move(96 + 648, 54)  # Center column
+        encounter_x = profile.horizontal_margin + profile.character_panel_width
+        self.encounter_pane = EncounterPanel(self, layout_profile=profile)
+        self.encounter_pane.move(encounter_x, profile.vertical_margin)
         self.encounter_pane.show()
-        
+
         # Log panel (top right)
-        self.log_panel = LogPanel(self)
-        self.log_panel.move(96 + 648 + 648, 54)  # Right column
+        right_column_x = encounter_x + profile.encounter_panel_width
+        self.log_panel = LogPanel(self, layout_profile=profile)
+        self.log_panel.move(right_column_x, profile.vertical_margin)
         self.log_panel.show()
-        
+
         # Equipment panel (bottom right)
-        self.equipment_panel = EquipmentPanel(self)
-        self.equipment_panel.move(96 + 648 + 648, 54 + 486)  # Below log
+        self.equipment_panel = EquipmentPanel(self, layout_profile=profile)
+        self.equipment_panel.move(
+            right_column_x,
+            profile.vertical_margin + profile.log_panel_height,
+        )
         self.equipment_panel.show()
-        
+
         # Action cards (bottom left)
-        self.action_panel = ActionPanel(self)
-        self.action_panel.move(96, 1080 - 54 - 300)  # Bottom left
+        self.action_panel = ActionPanel(self, layout_profile=profile)
+        action_y = (
+            profile.min_window_height
+            - profile.vertical_margin
+            - profile.action_panel_height
+        )
+        self.action_panel.move(profile.horizontal_margin, action_y)
         self.action_panel.show()
         self.action_panel.raise_()
-        
+
         # Theme toggle button (top right, near log panel)
         self.theme_toggle_button = QPushButton("[MOON] Dark", self)  # Start with moon for switching to dark
-        self.theme_toggle_button.setGeometry(96 + 648 + 648 - 100, 20, 90, 30)  # Top right, above log panel
+        toggle_x = right_column_x + profile.log_panel_width - profile.theme_toggle_inset
+        self.theme_toggle_button.setGeometry(
+            toggle_x,
+            20,
+            profile.theme_toggle_width,
+            profile.theme_toggle_height,
+        )
         self.theme_toggle_button.clicked.connect(self._toggle_theme)
         self.theme_toggle_button.setToolTip("Toggle between Light and Dark themes (Ctrl+T)")
         self.theme_toggle_button.show()

--- a/ui/themes.py
+++ b/ui/themes.py
@@ -9,48 +9,48 @@ from __future__ import annotations
 
 # Light theme based on Light_.JPG color palette
 LIGHT_THEME = {
-    # Base colors from Light_.JPG - warm, bright tones (made lighter)
-    "background": "#f5e9d8",          # Much lighter warm cream background
-    "surface": "#f0e1d0",             # Light warm beige for panels
-    "text": "#3d3530",                # Darker muted charcoal-brown text
-    "text_secondary": "#5a504a",      # Medium muted gray-brown for secondary text
-    
+    # Base colors from Light_.JPG - warm, bright tones with higher contrast
+    "background": "#faf2e7",          # Brighter warm cream background
+    "surface": "#f4e5d4",             # Light warm beige for panels
+    "text": "#2b211c",                # Deep brown text for stronger contrast
+    "text_secondary": "#4c3d35",      # Muted brown-gray for secondary text
+
     # Accent colors from Light_.JPG swatches
-    "accent_primary": "#8b5a3c",      # Rich reddish-brown from palette
-    "accent_secondary": "#a0673f",    # Warm orange-brown accent
-    "accent_tertiary": "#5c8b7a",     # Blue-teal from palette (use for all blue elements)
-    "accent_quaternary": "#d4956b",   # Light orange tone
-    
+    "accent_primary": "#7c4f32",      # Rich reddish-brown from palette
+    "accent_secondary": "#a45f38",    # Warm orange-brown accent
+    "accent_tertiary": "#3f7663",     # Blue-teal accent used for selections
+    "accent_quaternary": "#cf8a5b",   # Light orange tone
+
     # UI element colors
-    "button": "#a0673f",              # Warm orange-brown for buttons
-    "button_hover": "#b8784a",        # Lighter on hover
-    "button_pressed": "#8b5a3c",      # Darker when pressed
-    "border": "#d0c4b0",              # Lighter soft brown border
-    "selection": "#5c8b7a",           # Blue-teal for selections, links, active states
-    "highlight": "#fbf5ef",           # Even lighter warm highlight
+    "button": "#a45f38",              # Warm orange-brown for buttons
+    "button_hover": "#bb7346",        # Lighter on hover
+    "button_pressed": "#7c4f32",      # Darker when pressed
+    "border": "#c9b59c",              # Soft but pronounced border
+    "selection": "#3f7663",           # Blue-teal for selections, links, active states
+    "highlight": "#fff9f1",           # Even lighter warm highlight
 }
 
 # Dark theme based on Dark.JPG color palette
 DARK_THEME = {
-    # Base colors from Dark.JPG - deep, rich tones
-    "background": "#2d2419",          # Deep brown-black from darkest swatch
-    "surface": "#3a3025",             # Slightly lighter dark brown for panels
-    "text": "#d4c4a8",                # Light warm cream text for readability
-    "text_secondary": "#b8a890",      # Muted cream for secondary text
-    
+    # Base colors from Dark.JPG - deep, rich tones with elevated contrast
+    "background": "#1f150d",          # Deeper brown-black for strong contrast
+    "surface": "#2d2116",             # Slightly lighter dark brown for panels
+    "text": "#f2e6cf",                # Bright warm cream text for readability
+    "text_secondary": "#d6c6ac",      # Muted cream for secondary text
+
     # Accent colors from Dark.JPG swatches
-    "accent_primary": "#5c4a38",      # Medium brown from palette
-    "accent_secondary": "#6b5645",    # Warm brown accent
-    "accent_tertiary": "#4a6b5c",     # Blue-teal from palette (use for all blue elements)
-    "accent_quaternary": "#7a6350",   # Warm brown-gray tone
-    
+    "accent_primary": "#5b4633",      # Medium brown from palette
+    "accent_secondary": "#74543c",    # Warm brown accent
+    "accent_tertiary": "#3d6d5a",     # Blue-teal from palette (use for all blue elements)
+    "accent_quaternary": "#8a6748",   # Warm brown-gray tone
+
     # UI element colors for dark theme
-    "button": "#5c4a38",              # Medium brown for buttons
-    "button_hover": "#6b5645",        # Lighter brown on hover
-    "button_pressed": "#453529",      # Darker when pressed
-    "border": "#4a3e32",              # Subtle dark brown border
-    "selection": "#4a6b5c",           # Blue-teal for selections, links, active states
-    "highlight": "#3a3025",           # Subtle dark highlight
+    "button": "#5b4633",              # Medium brown for buttons
+    "button_hover": "#74543c",        # Lighter brown on hover
+    "button_pressed": "#3d2d20",      # Darker when pressed
+    "border": "#4c3a2a",              # Pronounced dark brown border
+    "selection": "#3d6d5a",           # Blue-teal for selections, links, active states
+    "highlight": "#302217",           # Subtle dark highlight
 }
 
 def build_stylesheet(palette: dict[str, str]) -> str:


### PR DESCRIPTION
## Summary
- add layout profile definitions and variant entry points for 10% and 20% spacing adjustments
- refactor the main window and key panels to size from the selected layout profile while aligning widget styling with theme palettes
- refresh theme color palettes and action card styling to improve light/dark contrast

## Testing
- pytest *(fails: environment missing Qt/OpenGL libraries and database tables)*

------
https://chatgpt.com/codex/tasks/task_e_68d20bd52ba8832b8fe3aa2eeed41b62