### PR TITLE
Integrate Ollama-driven campaign narratives

### DIFF
--- a/encounter_pane/campaign/conan.json
+++ b/encounter_pane/campaign/conan.json
@@ -27,5 +27,9 @@
     "Cleric",
     "Warlock",
     "Wizard"
-  ]
-}
+  ],
+  "description": "A gritty sword-and-sorcery saga of survival, cruel sorcery, and desperate alliances.",
+  "llm_model": "mistral:7b-instruct",
+  "lora_adapter": "conan-hyborian-lora",
+  "narrative_prompt": "You are the LoRA-honed chronicler for the $campaign_name campaign, steeped in $campaign_style brutality. Based on the structured data below, deliver 2-3 sentences portraying the $entity_type named $entity_name with pulpy intensity. Highlight danger, scarcity, and hard-won steel. Remain under 70 words, keep mechanics minimal, and draw on:\n$entity_json"
+ }

--- a/encounter_pane/campaign/golden.json
+++ b/encounter_pane/campaign/golden.json
@@ -30,5 +30,8 @@
     "Wizard"
   ],
   "guaranteed_hoards": true,
-  "description": "A campaign where magical items are more common and encounters often yield treasure hoards containing magical equipment."
-}
+  "description": "A campaign where magical items are more common and encounters often yield treasure hoards containing magical equipment.",
+  "llm_model": "mistral:7b-instruct",
+  "lora_adapter": "golden-age-lora",
+  "narrative_prompt": "You are the LoRA-tuned narrator for the $campaign_name campaign, a $campaign_style tale of radiant heroics. Using the details below, craft 2-3 sentences that describe the $entity_type named $entity_name as it appears within this realm. Emphasise optimism, legendary artefacts, and the promise of destiny. Keep the description under 70 words, avoid explicit mechanics, and draw inspiration from:\n$entity_json"
+ }

--- a/encounter_pane/campaign_frame.py
+++ b/encounter_pane/campaign_frame.py
@@ -3,7 +3,7 @@ import json
 from typing import Dict, List, Optional
 
 class CampaignFrame:
-    def __init__(self, data=None, name: str = None, monster_type_weights: Optional[Dict[str, float]] = None, difficulty_distribution: Dict[str, float] = None, rest_rules: Dict[str, float] = None, style: str = "", available_classes: Optional[List[str]] = None, monster_alignment_rules: Optional[Dict[str, any]] = None, guaranteed_hoards: bool = False):
+    def __init__(self, data=None, name: str = None, monster_type_weights: Optional[Dict[str, float]] = None, difficulty_distribution: Dict[str, float] = None, rest_rules: Dict[str, float] = None, style: str = "", available_classes: Optional[List[str]] = None, monster_alignment_rules: Optional[Dict[str, any]] = None, guaranteed_hoards: bool = False, description: str = "", llm_model: Optional[str] = None, lora_adapter: Optional[str] = None, narrative_prompt: Optional[str] = None):
         if isinstance(data, dict):
             # Initialize from dict (JSON loading)
             self.name = data.get('name', '')
@@ -14,6 +14,10 @@ class CampaignFrame:
             self.available_classes = data.get('available_classes', [])
             self.monster_alignment_rules = data.get('monster_alignment_rules', {})
             self.guaranteed_hoards = data.get('guaranteed_hoards', False)
+            self.description = data.get('description', '')
+            self.llm_model = data.get('llm_model')
+            self.lora_adapter = data.get('lora_adapter')
+            self.narrative_prompt = data.get('narrative_prompt')
         else:
             # Initialize from individual parameters
             self.name = name or data or ''
@@ -24,6 +28,10 @@ class CampaignFrame:
             self.available_classes = available_classes or []
             self.monster_alignment_rules = monster_alignment_rules or {}
             self.guaranteed_hoards = guaranteed_hoards
+            self.description = description
+            self.llm_model = llm_model
+            self.lora_adapter = lora_adapter
+            self.narrative_prompt = narrative_prompt
 
     def to_dict(self):
         return {
@@ -34,7 +42,11 @@ class CampaignFrame:
             "style": self.style,
             "available_classes": self.available_classes,
             "monster_alignment_rules": self.monster_alignment_rules,
-            "guaranteed_hoards": self.guaranteed_hoards
+            "guaranteed_hoards": self.guaranteed_hoards,
+            "description": self.description,
+            "llm_model": self.llm_model,
+            "lora_adapter": self.lora_adapter,
+            "narrative_prompt": self.narrative_prompt,
         }
 
     def save_to_file(self, path: str):

--- a/encounter_pane/encounter_generator.py
+++ b/encounter_pane/encounter_generator.py
@@ -2,7 +2,10 @@ import random
 import json
 import os
 import re
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from services.campaign_description_service import CampaignDescriptionService
 
 # XP budgets per encounter level/difficulty
 XP_BUDGETS = [
@@ -182,9 +185,36 @@ class RandomBag:
 
 
 class EncounterGenerator:
-    def __init__(self, frame: CampaignFrame):
+    def __init__(self, frame: CampaignFrame, description_service: Optional["CampaignDescriptionService"] = None):
         self.frame = frame
         self.bags: Dict[int, RandomBag] = {}
+        self.description_service = description_service
+
+    def _attach_monster_narrative(self, monsters: List[Dict[str, Any]], level: int, difficulty: str) -> List[Dict[str, Any]]:
+        """Return copies of ``monsters`` with optional narrative descriptions."""
+
+        decorated: List[Dict[str, Any]] = []
+        for monster in monsters:
+            monster_copy = monster.copy()
+
+            if self.description_service:
+                context = {
+                    "name": monster_copy.get("name"),
+                    "type": monster_copy.get("type"),
+                    "alignment": monster_copy.get("alignment"),
+                    "challenge_rating": monster_copy.get("cr_str", monster_copy.get("cr")),
+                    "xp": monster_copy.get("xp"),
+                    "average_hp": monster_copy.get("average_hp"),
+                    "encounter_level": level,
+                    "encounter_difficulty": difficulty,
+                }
+                description = self.description_service.generate_description("monster", context, self.frame)
+                if description:
+                    monster_copy["narrative_description"] = description
+
+            decorated.append(monster_copy)
+
+        return decorated
 
     def get_budget(self, level: int, difficulty: str) -> int:
         for entry in XP_BUDGETS:
@@ -267,10 +297,11 @@ class EncounterGenerator:
                 else:
                     break
 
+            monsters = self._attach_monster_narrative(encounter, level, difficulty)
             return {
                 "level": level,
                 "difficulty": difficulty,
-                "monsters": encounter,
+                "monsters": monsters,
                 "total_xp": total
             }
         else:
@@ -284,9 +315,10 @@ class EncounterGenerator:
                     total += m["xp"]
                 else:
                     break
+            monsters = self._attach_monster_narrative(encounter, level, difficulty)
             return {
                 "level": level,
                 "difficulty": difficulty,
-                "monsters": encounter,
+                "monsters": monsters,
                 "total_xp": total
             }

--- a/encounter_pane/encounter_panel.py
+++ b/encounter_pane/encounter_panel.py
@@ -39,6 +39,7 @@ from .spell_selection_widget import SpellSelectionWidget
 from .skill_selection_dialog import SkillSelectionDialog
 from services.skill_challenge_manager import SkillChallengeManager
 from services.skill_challenge_rewards import SkillChallengeRewards
+from services.campaign_description_service import CampaignDescriptionService
 from services.stealth_mechanics import StealthMechanicsService
 # Monster models no longer needed - using direct SQL queries and local dataclasses
 from dataclasses import dataclass, field
@@ -515,6 +516,7 @@ class EncounterPanel(QWidget):
         # Initialize encounter generator and campaign frame
         self.encounter_generator = None
         self.campaign_frame = None
+        self.description_service = CampaignDescriptionService()
         self._load_campaign_frame()
         
         # Track current encounter instances
@@ -3680,7 +3682,7 @@ class EncounterPanel(QWidget):
             self.campaign_frame = campaign_frame
 
             print(f"[DEBUG] Creating EncounterGenerator...")
-            self.encounter_generator = EncounterGenerator(campaign_frame)
+            self.encounter_generator = EncounterGenerator(campaign_frame, description_service=self.description_service)
             print(f"[DEBUG] EncounterGenerator created successfully")
 
             print(f"[DEBUG] Loaded campaign: {getattr(campaign_frame, 'name', 'Unknown')}")
@@ -3704,7 +3706,7 @@ class EncounterPanel(QWidget):
             }
             campaign_frame = CampaignFrame(default_frame_data)
             self.campaign_frame = campaign_frame
-            self.encounter_generator = EncounterGenerator(campaign_frame)
+            self.encounter_generator = EncounterGenerator(campaign_frame, description_service=self.description_service)
     
     def _generate_selected_encounter(self):
         """Generate encounter based on selected type."""
@@ -3747,6 +3749,21 @@ class EncounterPanel(QWidget):
         """Generate a trap encounter with automated resolution."""
         level = self._get_character_level() or 1
         trap = generate_trap(level)
+
+        if self.description_service and self.campaign_frame and trap:
+            trap_context = {
+                "name": f"{trap.get('type', 'Trap')} Trap",
+                "type": trap.get('type'),
+                "effects": trap.get('effects'),
+                "damage": trap.get('damage'),
+                "dc": trap.get('dc'),
+                "to_hit": trap.get('toHit'),
+                "xp": trap.get('xp'),
+                "level": level,
+            }
+            narrative = self.description_service.generate_description("trap", trap_context, self.campaign_frame)
+            if narrative:
+                trap['narrative_description'] = narrative
 
         self._active_trap_state = {
             'type': trap['type'],
@@ -3830,14 +3847,22 @@ class EncounterPanel(QWidget):
 
 
     def _format_trap_summary(self, trap: dict, extra: Optional[str] = None) -> str:
-        lines = [
-            f"Trap Type: {trap['type']}",
-            f"Description: {trap['description']}",
+        lines = [f"Trap Type: {trap['type']}"]
+
+        narrative = trap.get('narrative_description')
+        if narrative:
+            lines.append(f"Narrative: {narrative}")
+
+        base_description = trap.get('description', '')
+        if base_description:
+            lines.append(f"Description: {base_description}")
+
+        lines.extend([
             f"DC {trap['dc']} / Attack Bonus +{trap['toHit']}",
             f"Damage: {trap['damage']}",
             f"Effects: {trap['effects']}",
             f"XP: {trap['xp']}",
-        ]
+        ])
         if extra:
             lines.append('')
             lines.append(extra)
@@ -3868,7 +3893,9 @@ class EncounterPanel(QWidget):
         title.setStyleSheet("font-weight: bold; color: #ffcc66;")
         layout.addWidget(title)
 
-        description = QLabel("This setback springs without warning if unnoticed.")
+        narrative = trap.get('narrative_description')
+        description_text = narrative or "This setback springs without warning if unnoticed."
+        description = QLabel(description_text)
         description.setWordWrap(True)
         layout.addWidget(description)
 
@@ -3946,7 +3973,9 @@ class EncounterPanel(QWidget):
         title.setStyleSheet("font-weight: bold; color: #ff9955;")
         layout.addWidget(title)
 
-        warning = QLabel("You see a dangerous area - surely treasure is nearby.")
+        narrative = trap.get('narrative_description')
+        warning_text = narrative or "You see a dangerous area - surely treasure is nearby."
+        warning = QLabel(warning_text)
         warning.setWordWrap(True)
         layout.addWidget(warning)
 
@@ -4341,6 +4370,20 @@ class EncounterPanel(QWidget):
             self.encounter_details_text.setPlainText("No hazards available for this level.")
             return
 
+        if self.description_service and self.campaign_frame:
+            hazard_context = {
+                "name": hazard.get('name'),
+                "dc": hazard.get('dc'),
+                "effect": hazard.get('effect') or hazard.get('failure_effect'),
+                "damage": hazard.get('damage_dice'),
+                "damage_type": hazard.get('damage_type'),
+                "level": character_level,
+                "base_description": hazard.get('description'),
+            }
+            narrative = self.description_service.generate_description("hazard", hazard_context, self.campaign_frame)
+            if narrative:
+                hazard['narrative_description'] = narrative
+
         self.hazard_widget = HazardWidget()
         self.hazard_widget.set_character_data(character_data)
 
@@ -4397,7 +4440,7 @@ class EncounterPanel(QWidget):
         if not character_data:
             self.encounter_details_text.setPlainText("No active character found.")
             return
-        self.encounter_details_text.setPlainText("A travelling vendor offers goods.")
+        description_text = "A travelling vendor offers goods."
         self.encounters_list.setVisible(False)
         self.monsters_frame.setVisible(False)
 
@@ -4407,6 +4450,21 @@ class EncounterPanel(QWidget):
 
         self.vendor_widget = ShopInterface(character_data, vendor_size, self)
         self.encounters_layout.addWidget(self.vendor_widget)
+
+        if self.description_service and self.campaign_frame:
+            inventory = getattr(self.vendor_widget, 'shop_inventory', [])
+            vendor_context = {
+                "name": "Travelling Vendor",
+                "shop_size": vendor_size.size_name,
+                "inventory_count": len(inventory),
+                "rarities": sorted({item.get('rarity', 'common') for item in inventory if isinstance(item, dict)}),
+                "character_level": character_data.get('level'),
+            }
+            narrative = self.description_service.generate_description("vendor", vendor_context, self.campaign_frame)
+            if narrative:
+                description_text = narrative
+
+        self.encounter_details_text.setPlainText(description_text)
 
     def _generate_monster_encounter(self):
         """Generate a random monster encounter based on active character level."""
@@ -4505,7 +4563,13 @@ class EncounterPanel(QWidget):
                 else:
                     cr_display = str(cr)
                     
-                monster_details.append(f"{monster['name']} (CR {cr_display}, {monster_xp} XP)")
+                detail = f"{monster['name']} (CR {cr_display}, {monster_xp} XP)"
+                narrative = monster.get('narrative_description')
+                if narrative:
+                    narrative_lines = [line.strip() for line in narrative.splitlines() if line.strip()]
+                    if narrative_lines:
+                        detail += "\n    " + "\n    ".join(narrative_lines)
+                monster_details.append(detail)
             
             # Create detailed encounter description
             if len(monster_details) == 1:

--- a/encounter_pane/hazard_widget.py
+++ b/encounter_pane/hazard_widget.py
@@ -96,7 +96,7 @@ class HazardWidget(QWidget):
 
         self.title_label.setText(hazard.get('name', 'Unknown Hazard'))
 
-        description = hazard.get('description', 'A dangerous environmental hazard.')
+        description = hazard.get('narrative_description') or hazard.get('description', 'A dangerous environmental hazard.')
         self.description_text.setPlainText(description)
 
         mechanics_lines = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ PyQt6>=6.5.0
 # Logging
 loguru>=0.7.0
 
+# Networking / API access
+requests>=2.31.0
+
 # Development/Optional
 pytest>=7.0.0
 black>=23.0.0

--- a/services/campaign_description_service.py
+++ b/services/campaign_description_service.py
@@ -1,0 +1,213 @@
+"""Narrative description helper backed by a lightweight Ollama model.
+
+This service builds a rich prompt using campaign frame data and entity context
+(monsters, vendors, hazards, traps) and asks a small language model hosted by
+Ollama to produce a short descriptive blurb. The service is designed to work in
+resource-constrained environments (≤16 GB) by defaulting to a light-weight
+model such as ``mistral:7b-instruct``. When Ollama is unavailable the generator
+falls back to deterministic text so that the rest of the application continues
+functioning.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from dataclasses import dataclass
+from string import Template
+from typing import Any, Dict, Optional
+
+
+def _load_requests_module():
+    if importlib.util.find_spec("requests") is None:
+        class _RequestsStub:
+            class RequestException(RuntimeError):
+                """Raised when HTTP requests are unavailable."""
+
+            class Session:  # noqa: D401 - simple stub
+                def post(self, *args, **kwargs):  # noqa: D401 - simple stub
+                    raise _RequestsStub.RequestException(
+                        "The 'requests' package is required for Ollama integration."
+                    )
+
+        return _RequestsStub()
+
+    import requests  # type: ignore
+
+    return requests
+
+
+requests = _load_requests_module()
+
+
+@dataclass
+class DescriptionRequest:
+    """Container for the information required to build a prompt."""
+
+    entity_type: str
+    entity_data: Dict[str, Any]
+    campaign_frame: Any  # Deliberately loose typing to avoid circular imports
+
+
+class CampaignDescriptionService:
+    """Generate campaign-aware descriptions using a local Ollama model."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        default_model: Optional[str] = None,
+        request_timeout: float = 30.0,
+    ) -> None:
+        self.base_url = base_url or os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
+        self.default_model = default_model or os.getenv("OLLAMA_MODEL", "mistral:7b-instruct")
+        self.request_timeout = request_timeout
+        self.session = requests.Session()
+
+        # Default prompt uses string.Template placeholders to avoid brace escaping
+        self._default_prompt = Template(
+            """
+You are the narrative voice for the $campaign_name campaign.
+Campaign tone: $campaign_style
+Campaign summary: $campaign_description
+
+Write 2-3 sentences that vividly describe the $entity_type named $entity_name.
+Keep the response under 70 words, focus on mood and stakes, and avoid game
+mechanics unless they reinforce the tone. Use the structured reference data
+below as inspiration:
+$entity_json
+"""
+        )
+
+    def generate_description(
+        self,
+        entity_type: str,
+        entity_data: Optional[Dict[str, Any]],
+        campaign_frame: Any,
+    ) -> Optional[str]:
+        """Return a short description or ``None`` if generation fails.
+
+        Parameters
+        ----------
+        entity_type:
+            Category of content (``monster``, ``vendor``, ``hazard``, ``trap``).
+        entity_data:
+            Structured details about the entity. When ``None`` a fallback string
+            is returned.
+        campaign_frame:
+            Campaign metadata used to tailor the tone and LoRA adapter.
+        """
+
+        if not entity_data:
+            return self._fallback_description(entity_type, {}, campaign_frame)
+
+        request = DescriptionRequest(entity_type=entity_type, entity_data=entity_data, campaign_frame=campaign_frame)
+
+        try:
+            prompt = self._build_prompt(request)
+        except Exception as exc:  # noqa: BLE001 - defensive conversion to fallback
+            print(f"[LLM] Failed to build prompt: {exc}")
+            return self._fallback_description(entity_type, entity_data, campaign_frame)
+
+        payload: Dict[str, Any] = {
+            "model": getattr(campaign_frame, "llm_model", None) or self.default_model,
+            "prompt": prompt,
+            "stream": False,
+        }
+
+        lora_adapter = getattr(campaign_frame, "lora_adapter", None)
+        if lora_adapter:
+            payload["options"] = {"lora": lora_adapter}
+
+        try:
+            response = self.session.post(
+                f"{self.base_url}/api/generate",
+                json=payload,
+                timeout=self.request_timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            text = data.get("response")
+            if isinstance(text, str) and text.strip():
+                return text.strip()
+
+            # Some Ollama builds return streaming chunks even with ``stream=False``
+            # and aggregate them under ``data``.
+            if "data" in data and isinstance(data["data"], list):
+                combined = "".join(chunk.get("response", "") for chunk in data["data"] if isinstance(chunk, dict))
+                if combined.strip():
+                    return combined.strip()
+
+        except requests.RequestException as exc:
+            print(f"[LLM] Ollama request failed: {exc}")
+        except ValueError as exc:  # JSON decoding errors
+            print(f"[LLM] Failed to parse Ollama response: {exc}")
+
+        return self._fallback_description(entity_type, entity_data, campaign_frame)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _build_prompt(self, request: DescriptionRequest) -> str:
+        campaign = request.campaign_frame
+        entity_data = request.entity_data
+        entity_name = entity_data.get("name") or entity_data.get("title") or entity_data.get("id", request.entity_type.title())
+
+        # Create JSON block and escape braces for Template substitution.
+        entity_json = json.dumps(entity_data, indent=2, sort_keys=True)
+
+        prompt_template_text = getattr(campaign, "narrative_prompt", None) or self._default_prompt.template
+        template = Template(prompt_template_text)
+
+        prompt = template.safe_substitute(
+            campaign_name=getattr(campaign, "name", "Unnamed Campaign") or "Unnamed Campaign",
+            campaign_style=getattr(campaign, "style", "") or "distinctive fantasy",
+            campaign_description=getattr(campaign, "description", "") or "",
+            entity_type=request.entity_type,
+            entity_name=entity_name,
+            entity_json=entity_json,
+        )
+        return prompt.strip()
+
+    def _fallback_description(
+        self,
+        entity_type: str,
+        entity_data: Dict[str, Any],
+        campaign_frame: Any,
+    ) -> str:
+        """Return a deterministic blurb when Ollama is unavailable."""
+
+        campaign_style = getattr(campaign_frame, "style", "") or getattr(campaign_frame, "name", "the campaign")
+        campaign_desc = getattr(campaign_frame, "description", "")
+        descriptor = campaign_desc if campaign_desc else f"the {campaign_style} setting"
+
+        name = entity_data.get("name") or entity_data.get("title") or entity_data.get("type", entity_type.title())
+
+        if entity_type == "monster":
+            creature_type = entity_data.get("type", "creature")
+            return (
+                f"{name} embodies the dangers of {descriptor}. Its {creature_type} instincts and presence hint at the "
+                "challenges awaiting bold adventurers."
+            )
+        if entity_type == "vendor":
+            size = entity_data.get("shop_size", "travelling")
+            stock = entity_data.get("inventory_count") or "an assortment of"
+            return (
+                f"A {size} merchant tied to {descriptor} lays out {stock} wares, their patter coloured by local legends "
+                "and whispered opportunities."
+            )
+        if entity_type == "hazard":
+            hazard_name = name or "hazard"
+            effect = entity_data.get("effect") or entity_data.get("failure_effect") or "lingering danger"
+            return (
+                f"{hazard_name} lurks in {descriptor}, threatening travellers with {effect}. Keen senses and teamwork are "
+                "the surest defence."
+            )
+        if entity_type == "trap":
+            trap_type = entity_data.get("type", "hidden device")
+            danger = entity_data.get("effects") or entity_data.get("damage") or "harm"
+            return (
+                f"A {trap_type.lower()} trap crafted in {descriptor} waits patiently to unleash {danger}. Observant "
+                "adventurers might still twist fate in their favour."
+            )
+
+        return f"The {entity_type} reflects the tone of {descriptor}, adding colour to the adventure."

--- a/services/hazard_service.py
+++ b/services/hazard_service.py
@@ -31,6 +31,8 @@ class HazardService:
         for row in rows:
             hazard = dict(row)
             hazard['xp'] = XP_BY_LEVEL_LOW.get(character_level, 50)
+            if not hazard.get('description') and hazard.get('effect'):
+                hazard['description'] = hazard['effect']
             hazards.append(hazard)
 
         return hazards
@@ -51,7 +53,10 @@ class HazardService:
         conn.close()
 
         if row:
-            return dict(row)
+            hazard = dict(row)
+            if not hazard.get('description') and hazard.get('effect'):
+                hazard['description'] = hazard['effect']
+            return hazard
         return None
 
     def apply_gear_bonus(self, hazard: Dict[str, Any], gear_items: List[str]) -> Dict[str, int]:

--- a/tests/test_campaign_description_service.py
+++ b/tests/test_campaign_description_service.py
@@ -1,0 +1,28 @@
+import pytest
+
+from encounter_pane.campaign_frame import CampaignFrame
+from services.campaign_description_service import CampaignDescriptionService
+
+
+@pytest.fixture
+def campaign_frame():
+    data = {
+        "name": "Test",
+        "style": "grimdark",
+        "monster_type_weights": {},
+        "difficulty_distribution": {},
+        "rest_rules": {},
+        "available_classes": [],
+    }
+    return CampaignFrame(data)
+
+
+def test_generate_description_fallback(campaign_frame):
+    service = CampaignDescriptionService(base_url="http://127.0.0.1:9", request_timeout=0.1)
+    description = service.generate_description(
+        "monster",
+        {"name": "Goblin Skirmisher", "type": "humanoid", "xp": 50},
+        campaign_frame,
+    )
+    assert "Goblin Skirmisher" in description
+    assert "grim" in description.lower()


### PR DESCRIPTION
## Summary
- add a campaign-aware description service that talks to a local Ollama model with graceful fallbacks
- extend campaign frame metadata and encounter generation so monsters, traps, hazards, and vendors receive frame-tailored narratives
- surface the generated text in encounter UI elements, update hazard handling, and cover the fallback path with a regression test

## Testing
- pytest tests/test_campaign_description_service.py

------
https://chatgpt.com/codex/tasks/task_e_68de46307be8832bb443532cbeae39b1