### PR TITLE
Add Windows agentic harness service for Claude Code automation

### DIFF
--- a/docs/agentic_harness_plan.yaml
+++ b/docs/agentic_harness_plan.yaml
@@ -1,0 +1,31 @@
+version: 1
+last_updated: null
+pauses: []
+tasks:
+  - id: qt6-ui-verification-baseline
+    description: Verify that the existing Qt6 UI smoke tests run successfully as a baseline.
+    status: pending
+    tests:
+      - tests/test_spell_cards_qt6.py::test_spell_action_cards
+      - tests/test_stage_1_3_ui.py::test_condition_badge_creation
+    documentation_targets:
+      - docs/agentic_harness_plan.yaml
+    subtasks: []
+    history: []
+    last_result: null
+    last_success_at: null
+    max_retries: 5
+    retries: 0
+  - id: document-handoff-protocol
+    description: Capture the documentation hand-off workflow between the harness and Claude Code.
+    status: pending
+    tests:
+      - tests/test_spell_selection_ui.py::test_wizard_selection
+    documentation_targets:
+      - docs/agentic_harness_service.md
+    subtasks: []
+    history: []
+    last_result: null
+    last_success_at: null
+    max_retries: 5
+    retries: 0

--- a/docs/agentic_harness_reference.md
+++ b/docs/agentic_harness_reference.md
@@ -1,0 +1,19 @@
+# Talekeeper Agentic Harness Reference
+
+## Objective
+Design a resilient automation harness that coordinates Claude Code inside Visual Studio Code on Windows, drives
+implementation through a written plan, and validates each deliverable with Qt6 functional tests before accepting the
+work.
+
+## Acceptance Criteria
+- Harness reads tasks from `docs/agentic_harness_plan.yaml` and updates their status as work progresses.
+- Harness sends explicit task instructions, revision requests, and documentation prompts to the Claude Code extension.
+- Harness executes Qt6 pytest suites and only marks tasks complete when the tests succeed.
+- Harness records pauses and creates remediation subtasks when progress stalls or verification fails.
+- Harness enforces a documentation hand-off once verification passes.
+
+## Required Qt6 Tests
+- tests/test_spell_cards_qt6.py::test_spell_action_cards
+- tests/test_stage_1_3_ui.py::test_condition_badge_creation
+- tests/test_spell_selection_ui.py::test_wizard_selection
+

--- a/docs/agentic_harness_service.md
+++ b/docs/agentic_harness_service.md
@@ -1,0 +1,62 @@
+# Talekeeper Agentic Harness Windows Service
+
+This document explains how to run the Talekeeper agentic harness on Windows and how it collaborates with the Claude Code
+Visual Studio Code extension to deliver verified work.
+
+## Overview
+The harness continuously reviews the planning document (`docs/agentic_harness_plan.yaml`), assigns the next open task to
+Claude Code, and requires successful Qt6 functional tests before marking the task as complete. Every test run must prove
+that the user-facing behaviour is present in the game UI. After verification succeeds the harness prompts Claude Code to
+update the planning document with a summary of the work and the associated evidence.
+
+## Service Components
+- **Planning document** – YAML file that lists each automation task, their required Qt6 tests, and any documentation that
+  must be updated.
+- **Reference document** – Read-only markdown file (`docs/agentic_harness_reference.md`) that describes the non-negotiable
+  acceptance criteria and required Qt6 tests.
+- **Qt6 verifier** – Executes the specified pytest cases (usually from the `tests/` folder) and captures stdout/stderr as
+  proof of success or failure.
+- **Claude Code interface** – Sends JSON payloads to the Claude Code extension via the VS Code command line or a file
+  inbox specified by `CLAUDE_CODE_INBOX`.
+
+## Installation
+1. Ensure Python and the Talekeeper dependencies are installed, including the optional `PyYAML` dependency.
+2. Install `pywin32` to enable Python Windows services.
+3. From an elevated command prompt, install the service:
+   ```powershell
+   python -m talekeeper.services.agentic_harness.service install
+   ```
+4. Start the service:
+   ```powershell
+   python -m talekeeper.services.agentic_harness.service start
+   ```
+
+## Configuration Options
+The harness reads the following environment variables:
+- `VSCODE_CLAUDE_BINARY` – override the `code` executable used to issue commands.
+- `VSCODE_CLAUDE_COMMAND` – command identifier inside VS Code (defaults to `claude-code.runTask`).
+- `CLAUDE_CODE_INBOX` – path to a file inbox; when set the harness writes payloads instead of calling the CLI, allowing
+  the VS Code extension to poll the file for new instructions.
+
+The default configuration expects the planning document to live at `docs/agentic_harness_plan.yaml` and the reference
+criteria at `docs/agentic_harness_reference.md`. Update these paths inside `AgenticHarnessConfig` if your project uses a
+different structure.
+
+## Operational Flow
+1. **Task selection** – The harness looks for tasks marked `pending` or `needs_revision` in the planning document.
+2. **Instruction dispatch** – It sends Claude Code a JSON payload containing the task summary, required tests, and
+   context from the reference document.
+3. **Verification** – The harness runs the Qt6 tests listed for the task. Failures create remediation subtasks and trigger
+   a revision prompt for Claude Code.
+4. **Documentation hand-off** – After the tests succeed, the harness requests that Claude Code updates the planning
+   document and any target documentation.
+5. **Completion** – The task is marked `completed`, including timestamps and captured stdout/stderr from the successful
+   tests. The harness then moves to the next pending task.
+
+## Troubleshooting
+- Review the `pauses` section of the planning document to see why the harness stopped processing tasks.
+- Each task retains a history of status changes, retries, and subtask creation, making it easier to resume progress when
+  the service restarts.
+- The `CLAUDE_CODE_INBOX` integration is useful during development because it allows inspection of the payloads the
+  harness sends to Claude Code without needing to run VS Code.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "PyQt6>=6.5.0",
     "PyQt6-WebEngine>=6.5.0",
     "piper-tts>=1.2.0",
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/talekeeper/services/agentic_harness/__init__.py
+++ b/src/talekeeper/services/agentic_harness/__init__.py
@@ -1,0 +1,19 @@
+"""Agentic harness service package for orchestrating Claude Code automation."""
+
+from .planning import PlanningDocument, TaskRecord, SubtaskRecord
+from .reference import ReferenceDocument
+from .qt_test_verifier import QtTestVerifier, TestResult
+from .claude_interface import ClaudeCodeInterface
+from .service import AgenticHarness, AgenticHarnessConfig
+
+__all__ = [
+    "AgenticHarness",
+    "AgenticHarnessConfig",
+    "PlanningDocument",
+    "ReferenceDocument",
+    "QtTestVerifier",
+    "ClaudeCodeInterface",
+    "TaskRecord",
+    "SubtaskRecord",
+    "TestResult",
+]

--- a/src/talekeeper/services/agentic_harness/claude_interface.py
+++ b/src/talekeeper/services/agentic_harness/claude_interface.py
@@ -1,0 +1,146 @@
+"""Abstractions for interacting with the Claude Code VS Code extension."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .planning import TaskRecord
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ClaudeCommandResult:
+    """Represents the result of invoking a Claude Code command."""
+
+    command: str
+    payload_path: Optional[Path]
+    return_code: Optional[int]
+    stdout: str
+    stderr: str
+
+
+class ClaudeCodeInterface:
+    """Thin wrapper around the VS Code Claude Code extension automation hooks."""
+
+    def __init__(
+        self,
+        *,
+        vscode_binary: str | None = None,
+        command_id: str | None = None,
+        inbox_path: Path | None = None,
+        environment: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.vscode_binary = vscode_binary or os.environ.get("VSCODE_CLAUDE_BINARY", "code")
+        self.command_id = command_id or os.environ.get("VSCODE_CLAUDE_COMMAND", "claude-code.runTask")
+        self.inbox_path = inbox_path or self._resolve_inbox()
+        self.environment = environment or {}
+
+    # ------------------------------------------------------------------
+    # Public methods
+    # ------------------------------------------------------------------
+    def send_task(self, task: TaskRecord, *, context: Dict[str, Any]) -> ClaudeCommandResult:
+        """Send a task request to the Claude Code extension."""
+
+        payload = self._build_payload("task", task, context)
+        return self._deliver_payload(payload)
+
+    def request_revision(self, task: TaskRecord, failure_output: str) -> ClaudeCommandResult:
+        """Request a revision from Claude Code when verification fails."""
+
+        context = {
+            "failure_output": failure_output,
+            "instructions": textwrap.dedent(
+                """
+                Verification failed. Investigate the failing Qt6 tests, address the issues, and prepare
+                updated code along with documentation adjustments. Re-run the tests locally before marking
+                the task ready again.
+                """
+            ).strip(),
+        }
+        payload = self._build_payload("revision", task, context)
+        return self._deliver_payload(payload)
+
+    def request_documentation_update(self, task: TaskRecord, proof: str) -> ClaudeCommandResult:
+        """Ask Claude Code to document verified changes."""
+
+        context = {
+            "proof": proof,
+            "instructions": textwrap.dedent(
+                """
+                Functional Qt6 verification has passed. Update the planning document with a summary of the
+                work performed, reference the tests that prove the change, and ensure code documentation is
+                aligned with the delivered behavior.
+                """
+            ).strip(),
+        }
+        payload = self._build_payload("documentation", task, context)
+        return self._deliver_payload(payload)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _resolve_inbox(self) -> Optional[Path]:
+        env_path = os.environ.get("CLAUDE_CODE_INBOX")
+        return Path(env_path) if env_path else None
+
+    def _build_payload(self, intent: str, task: TaskRecord, context: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "intent": intent,
+            "task": {
+                "id": task.task_id,
+                "description": task.description,
+                "tests": task.tests,
+                "documentation_targets": task.documentation_targets,
+            },
+            "context": context,
+        }
+
+    def _deliver_payload(self, payload: Dict[str, Any]) -> ClaudeCommandResult:
+        serialized = json.dumps(payload, indent=2)
+        inbox_file: Optional[Path] = None
+        stdout = ""
+        stderr = ""
+        return_code: Optional[int] = None
+
+        if self.inbox_path:
+            self.inbox_path.parent.mkdir(parents=True, exist_ok=True)
+            inbox_file = self.inbox_path
+            inbox_file.write_text(serialized, encoding="utf-8")
+            LOGGER.info("Wrote Claude Code payload to inbox: %s", inbox_file)
+            command_repr = f"write:{inbox_file}"
+        else:
+            command = [self.vscode_binary, "--command", self.command_id, serialized]
+            env = os.environ.copy()
+            env.update(self.environment)
+            LOGGER.info("Invoking VS Code command: %s", " ".join(command))
+            try:
+                completed = subprocess.run(
+                    command,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                )
+            except OSError as error:
+                LOGGER.exception("Unable to invoke VS Code CLI for Claude Code: %s", error)
+                raise
+            stdout = completed.stdout or ""
+            stderr = completed.stderr or ""
+            return_code = completed.returncode
+            command_repr = " ".join(command)
+        return ClaudeCommandResult(
+            command=command_repr,
+            payload_path=inbox_file,
+            return_code=return_code,
+            stdout=stdout,
+            stderr=stderr,
+        )
+

--- a/src/talekeeper/services/agentic_harness/planning.py
+++ b/src/talekeeper/services/agentic_harness/planning.py
@@ -1,0 +1,284 @@
+"""Planning document management for the agentic harness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import threading
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import yaml
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+
+
+@dataclass
+class SubtaskRecord:
+    """Represents a remediation subtask captured in the planning document."""
+
+    created_at: str
+    summary: str
+    details: str
+    tests_attempted: List[str] = field(default_factory=list)
+
+
+@dataclass
+class TaskRecord:
+    """Represents a single task tracked in the planning document."""
+
+    task_id: str
+    description: str
+    status: str = "pending"
+    tests: List[str] = field(default_factory=list)
+    documentation_targets: List[str] = field(default_factory=list)
+    subtasks: List[SubtaskRecord] = field(default_factory=list)
+    history: List[Dict[str, str]] = field(default_factory=list)
+    last_result: Optional[str] = None
+    last_success_at: Optional[str] = None
+    max_retries: int = 3
+    retries: int = 0
+
+    def to_dict(self) -> Dict[str, object]:
+        """Convert the dataclass to a YAML-compatible dictionary."""
+
+        return {
+            "id": self.task_id,
+            "description": self.description,
+            "status": self.status,
+            "tests": list(self.tests),
+            "documentation_targets": list(self.documentation_targets),
+            "subtasks": [
+                {
+                    "created_at": sub.created_at,
+                    "summary": sub.summary,
+                    "details": sub.details,
+                    "tests_attempted": list(sub.tests_attempted),
+                }
+                for sub in self.subtasks
+            ],
+            "history": list(self.history),
+            "last_result": self.last_result,
+            "last_success_at": self.last_success_at,
+            "max_retries": self.max_retries,
+            "retries": self.retries,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "TaskRecord":
+        """Create a :class:`TaskRecord` from YAML data."""
+
+        subtasks = [
+            SubtaskRecord(
+                created_at=sub.get("created_at", ""),
+                summary=sub.get("summary", ""),
+                details=sub.get("details", ""),
+                tests_attempted=list(sub.get("tests_attempted", [])),
+            )
+            for sub in data.get("subtasks", [])
+        ]
+        return cls(
+            task_id=data.get("id", ""),
+            description=data.get("description", ""),
+            status=data.get("status", "pending"),
+            tests=list(data.get("tests", [])),
+            documentation_targets=list(data.get("documentation_targets", [])),
+            subtasks=subtasks,
+            history=list(data.get("history", [])),
+            last_result=data.get("last_result"),
+            last_success_at=data.get("last_success_at"),
+            max_retries=int(data.get("max_retries", 3)),
+            retries=int(data.get("retries", 0)),
+        )
+
+
+class PlanningDocument:
+    """Utility class for reading and writing the automation planning document."""
+
+    def __init__(self, document_path: Path) -> None:
+        self.path = Path(document_path)
+        self._lock = threading.RLock()
+        self._data: Dict[str, object] = {}
+        self._tasks: List[TaskRecord] = []
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def refresh(self) -> None:
+        """Load the planning document from disk."""
+
+        with self._lock:
+            if not self.path.exists():
+                self._data = self._default_document()
+                self._tasks = [TaskRecord.from_dict(task) for task in self._data["tasks"]]
+                self._write()
+                return
+
+            content = self.path.read_text(encoding="utf-8")
+            raw = yaml.safe_load(content) or {}
+            if "tasks" not in raw:
+                raw["tasks"] = []
+
+            self._data = raw
+            self._tasks = [TaskRecord.from_dict(task) for task in raw["tasks"]]
+
+    def list_tasks(self) -> List[TaskRecord]:
+        """Return a copy of the tracked tasks."""
+
+        with self._lock:
+            return [TaskRecord.from_dict(task.to_dict()) for task in self._tasks]
+
+    def get_next_task(self, *, allowed_statuses: Iterable[str] | None = None) -> Optional[TaskRecord]:
+        """Return the next task that matches the allowed statuses."""
+
+        if allowed_statuses is None:
+            allowed_statuses = ("pending", "needs_revision")
+        allowed = set(allowed_statuses)
+
+        with self._lock:
+            for task in self._tasks:
+                if task.status in allowed:
+                    return TaskRecord.from_dict(task.to_dict())
+        return None
+
+    def update_task(self, updated: TaskRecord) -> None:
+        """Persist an updated task."""
+
+        with self._lock:
+            for idx, task in enumerate(self._tasks):
+                if task.task_id == updated.task_id:
+                    self._tasks[idx] = updated
+                    break
+            else:
+                self._tasks.append(updated)
+            self._data["tasks"] = [task.to_dict() for task in self._tasks]
+            self._write()
+
+    def mark_status(self, task_id: str, status: str, *, note: Optional[str] = None) -> TaskRecord:
+        """Update the status of a task and persist the change."""
+
+        with self._lock:
+            task = self._get_task_mutable(task_id)
+            timestamp = self._timestamp()
+            history_entry = {"timestamp": timestamp, "status": status}
+            if note:
+                history_entry["note"] = note
+            task.history.append(history_entry)
+            task.status = status
+            self.update_task(task)
+            return TaskRecord.from_dict(task.to_dict())
+
+    def append_subtask(
+        self,
+        task_id: str,
+        summary: str,
+        details: str,
+        *,
+        tests_attempted: Optional[Iterable[str]] = None,
+    ) -> TaskRecord:
+        """Record a new subtask entry when work is paused or fails."""
+
+        with self._lock:
+            task = self._get_task_mutable(task_id)
+            subtask = SubtaskRecord(
+                created_at=self._timestamp(),
+                summary=summary,
+                details=details,
+                tests_attempted=list(tests_attempted or task.tests),
+            )
+            task.subtasks.append(subtask)
+            note = f"Added subtask: {summary}"
+            task.history.append({"timestamp": subtask.created_at, "status": task.status, "note": note})
+            self.update_task(task)
+            return TaskRecord.from_dict(task.to_dict())
+
+    def record_failure(self, task_id: str, result: str, *, tests: Optional[Iterable[str]] = None) -> TaskRecord:
+        """Record a failed verification attempt for a task."""
+
+        with self._lock:
+            task = self._get_task_mutable(task_id)
+            task.last_result = result
+            task.retries += 1
+            task.status = "needs_revision"
+            note = f"Verification failed (attempt {task.retries})"
+            task.history.append({"timestamp": self._timestamp(), "status": task.status, "note": note})
+            updated_tests = list(tests or task.tests)
+            subtask = SubtaskRecord(
+                created_at=self._timestamp(),
+                summary="Verification failure",
+                details=result,
+                tests_attempted=updated_tests,
+            )
+            task.subtasks.append(subtask)
+            task.history.append(
+                {
+                    "timestamp": subtask.created_at,
+                    "status": task.status,
+                    "note": "Created remediation subtask after failure",
+                }
+            )
+            self.update_task(task)
+            return TaskRecord.from_dict(task.to_dict())
+
+    def record_success(self, task_id: str, result: str) -> TaskRecord:
+        """Record a successful verification attempt."""
+
+        with self._lock:
+            task = self._get_task_mutable(task_id)
+            task.last_result = result
+            task.retries = 0
+            task.status = "completed"
+            timestamp = self._timestamp()
+            task.last_success_at = timestamp
+            task.history.append({"timestamp": timestamp, "status": "completed", "note": "Verification passed"})
+            self.update_task(task)
+            return TaskRecord.from_dict(task.to_dict())
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return the current document representation."""
+
+        with self._lock:
+            data = dict(self._data)
+            data["tasks"] = [task.to_dict() for task in self._tasks]
+            return data
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _default_document(self) -> Dict[str, object]:
+        return {
+            "version": 1,
+            "last_updated": self._timestamp(),
+            "tasks": [],
+            "pauses": [],
+        }
+
+    def _write(self) -> None:
+        self._data["last_updated"] = self._timestamp()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(self._data, handle, sort_keys=False)
+
+    def _timestamp(self) -> str:
+        return datetime.now().astimezone().strftime(ISO_FORMAT)
+
+    def _get_task_mutable(self, task_id: str) -> TaskRecord:
+        for task in self._tasks:
+            if task.task_id == task_id:
+                return task
+        raise KeyError(f"Task '{task_id}' not found in planning document")
+
+    # ------------------------------------------------------------------
+    # Pause management
+    # ------------------------------------------------------------------
+    def record_pause(self, reason: str) -> None:
+        """Record that the harness has paused execution."""
+
+        with self._lock:
+            pause_entry = {"timestamp": self._timestamp(), "reason": reason}
+            pauses = list(self._data.get("pauses", []))
+            pauses.append(pause_entry)
+            self._data["pauses"] = pauses
+            self._write()
+

--- a/src/talekeeper/services/agentic_harness/qt_test_verifier.py
+++ b/src/talekeeper/services/agentic_harness/qt_test_verifier.py
@@ -1,0 +1,85 @@
+"""Utilities for running Qt6 functional tests as proof of completion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class TestResult:
+    """Outcome of a Qt6 verification test run."""
+
+    success: bool
+    command: List[str]
+    output: str
+
+
+class QtTestVerifier:
+    """Runs Qt6-oriented pytest suites to validate Claude Code output."""
+
+    def __init__(
+        self,
+        *,
+        python_executable: str | None = None,
+        working_directory: Path | None = None,
+        extra_env: dict[str, str] | None = None,
+    ) -> None:
+        self.python_executable = python_executable or sys.executable
+        self.working_directory = working_directory
+        self.extra_env = extra_env or {}
+
+    def run_tests(self, tests: Sequence[str]) -> TestResult:
+        """Run the given pytest tests and return the result."""
+
+        if not tests:
+            LOGGER.info("No tests specified for Qt verifier; treating as success.")
+            return TestResult(success=True, command=[], output="No tests specified")
+
+        command = [self.python_executable, "-m", "pytest", "-q"]
+        command.extend(tests)
+        env = os.environ.copy()
+        env.update(self.extra_env)
+
+        LOGGER.info("Running Qt verification: %s", " ".join(command))
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=self.working_directory,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except OSError as error:
+            LOGGER.exception("Failed to invoke pytest for Qt verification: %s", error)
+            raise
+
+        output = (completed.stdout or "") + (completed.stderr or "")
+        success = completed.returncode == 0
+        if success:
+            LOGGER.info("Qt verification passed for tests: %s", tests)
+        else:
+            LOGGER.warning("Qt verification failed for tests %s with rc=%s", tests, completed.returncode)
+        return TestResult(success=success, command=command, output=output)
+
+    @staticmethod
+    def expand_tests(tests: Iterable[str], *, base_directory: Path | None = None) -> List[str]:
+        """Expand test paths relative to the provided base directory."""
+
+        expanded: List[str] = []
+        base = Path(base_directory) if base_directory else None
+        for test in tests:
+            candidate = Path(test)
+            if base and not candidate.is_absolute():
+                candidate = base / candidate
+            expanded.append(str(candidate))
+        return expanded
+

--- a/src/talekeeper/services/agentic_harness/reference.py
+++ b/src/talekeeper/services/agentic_harness/reference.py
@@ -1,0 +1,71 @@
+"""Reference document parsing utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+
+@dataclass
+class ReferenceDocument:
+    """Read-only reference document used to confirm completion criteria."""
+
+    path: Path
+    content: str
+    acceptance_criteria: List[str]
+    required_tests: List[str]
+    final_objective: str
+
+    @classmethod
+    def load(cls, path: Path) -> "ReferenceDocument":
+        resolved = Path(path)
+        text = resolved.read_text(encoding="utf-8")
+        acceptance = cls._parse_bullet_section(text, "Acceptance Criteria")
+        required = cls._parse_bullet_section(text, "Required Qt6 Tests")
+        objective = cls._parse_objective(text)
+        return cls(
+            path=resolved,
+            content=text,
+            acceptance_criteria=acceptance,
+            required_tests=required,
+            final_objective=objective,
+        )
+
+    # ------------------------------------------------------------------
+    # Parsing helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _parse_bullet_section(text: str, heading: str) -> List[str]:
+        lines = text.splitlines()
+        capture = False
+        items: List[str] = []
+        header = f"## {heading}"
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("## ") and stripped == header:
+                capture = True
+                continue
+            if capture and stripped.startswith("## ") and stripped != header:
+                break
+            if capture and stripped.startswith("- "):
+                items.append(stripped[2:].strip())
+        return items
+
+    @staticmethod
+    def _parse_objective(text: str) -> str:
+        lines = text.splitlines()
+        header = "## Objective"
+        capture = False
+        objective_lines: List[str] = []
+        for line in lines:
+            stripped = line.rstrip()
+            if stripped == header:
+                capture = True
+                continue
+            if capture:
+                if stripped.startswith("## ") and stripped != header:
+                    break
+                objective_lines.append(stripped)
+        return "\n".join([line.strip() for line in objective_lines if line.strip()])
+

--- a/src/talekeeper/services/agentic_harness/service.py
+++ b/src/talekeeper/services/agentic_harness/service.py
@@ -1,0 +1,197 @@
+"""Windows service orchestration for the Claude Code agentic harness."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+from .claude_interface import ClaudeCodeInterface
+from .planning import PlanningDocument, TaskRecord
+from .qt_test_verifier import QtTestVerifier
+from .reference import ReferenceDocument
+
+LOGGER = logging.getLogger(__name__)
+
+try:  # pragma: no cover - Windows-specific modules are optional in tests
+    import win32event
+    import win32service
+    import win32serviceutil
+    import servicemanager
+except ImportError:  # pragma: no cover
+    win32event = None
+    win32service = None
+    win32serviceutil = None
+    servicemanager = None
+
+
+@dataclass
+class AgenticHarnessConfig:
+    """Runtime configuration for the agentic harness."""
+
+    planning_document: Path
+    reference_document: Path
+    idle_sleep_seconds: int = 120
+    retry_sleep_seconds: int = 300
+    max_retries: int = 5
+
+
+class AgenticHarness:
+    """Core orchestration logic for the automation harness."""
+
+    def __init__(
+        self,
+        planning_document: PlanningDocument,
+        reference_document: ReferenceDocument,
+        claude_interface: ClaudeCodeInterface,
+        qt_verifier: QtTestVerifier,
+        *,
+        config: Optional[AgenticHarnessConfig] = None,
+    ) -> None:
+        self.planning_document = planning_document
+        self.reference_document = reference_document
+        self.claude_interface = claude_interface
+        self.qt_verifier = qt_verifier
+        self.config = config or AgenticHarnessConfig(
+            planning_document=planning_document.path,
+            reference_document=reference_document.path,
+        )
+        self._stop_event = threading.Event()
+
+    # ------------------------------------------------------------------
+    # Lifecycle management
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        LOGGER.info("Starting agentic harness loop")
+        while not self._stop_event.is_set():
+            task = self.planning_document.get_next_task()
+            if not task:
+                LOGGER.debug("No pending tasks found; sleeping for %s seconds", self.config.idle_sleep_seconds)
+                time.sleep(self.config.idle_sleep_seconds)
+                self.planning_document.record_pause("Idle - no pending tasks")
+                continue
+
+            LOGGER.info("Processing task %s", task.task_id)
+            self._process_task(task)
+
+    def stop(self) -> None:
+        LOGGER.info("Stopping agentic harness loop")
+        self._stop_event.set()
+        self.planning_document.record_pause("Harness stop requested")
+
+    # ------------------------------------------------------------------
+    # Task management
+    # ------------------------------------------------------------------
+    def _process_task(self, task: TaskRecord) -> None:
+        self.planning_document.mark_status(task.task_id, "in_progress", note="Harness picked up task")
+        context = self._build_task_context(task)
+        result = self.claude_interface.send_task(task, context=context)
+        LOGGER.debug("Sent task to Claude Code: %s", result.command)
+
+        retries = 0
+        max_retries = min(self.config.max_retries, task.max_retries)
+        while not self._stop_event.is_set():
+            verification = self.qt_verifier.run_tests(task.tests)
+            if verification.success:
+                LOGGER.info("Task %s passed verification", task.task_id)
+                self.planning_document.record_success(task.task_id, verification.output)
+                self.claude_interface.request_documentation_update(task, verification.output)
+                break
+
+            LOGGER.warning("Task %s verification failed; requesting revision", task.task_id)
+            self.planning_document.record_failure(task.task_id, verification.output, tests=task.tests)
+            self.claude_interface.request_revision(task, verification.output)
+            retries += 1
+            if retries >= max_retries:
+                LOGGER.error("Task %s exceeded maximum retries; pausing", task.task_id)
+                self.planning_document.record_pause(
+                    f"Max retries exceeded for task {task.task_id}; awaiting manual intervention"
+                )
+                break
+            LOGGER.debug(
+                "Sleeping for %s seconds before retrying task %s",
+                self.config.retry_sleep_seconds,
+                task.task_id,
+            )
+            time.sleep(self.config.retry_sleep_seconds)
+
+    def _build_task_context(self, task: TaskRecord) -> Dict[str, object]:
+        return {
+            "reference_objective": self.reference_document.final_objective,
+            "acceptance_criteria": self.reference_document.acceptance_criteria,
+            "required_tests": task.tests or self.reference_document.required_tests,
+            "documentation_targets": task.documentation_targets,
+        }
+
+
+class AgenticHarnessServiceBase:  # pragma: no cover - service wrapper is not tested on CI
+    """Base class wrapping the Windows service plumbing."""
+
+    _svc_name_ = "TalekeeperAgenticHarness"
+    _svc_display_name_ = "Talekeeper Agentic Harness"
+    _svc_description_ = "Automates Claude Code tasks with Qt6 verification."
+
+    def __init__(self, args):
+        if win32serviceutil is None:
+            raise RuntimeError("Windows service components are not available in this environment")
+        win32serviceutil.ServiceFramework.__init__(self, args)
+        self.stop_event = win32event.CreateEvent(None, 0, 0, None)
+        self.harness: Optional[AgenticHarness] = None
+
+    def SvcStop(self):  # type: ignore[override]
+        self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
+        if self.harness:
+            self.harness.stop()
+        win32event.SetEvent(self.stop_event)
+
+    def SvcDoRun(self):  # type: ignore[override]
+        servicemanager.LogInfoMsg("Talekeeper Agentic Harness service starting")
+        try:
+            self.harness = self.build_harness()
+            self.harness.run()
+        finally:
+            servicemanager.LogInfoMsg("Talekeeper Agentic Harness service stopped")
+
+    def build_harness(self) -> AgenticHarness:
+        raise NotImplementedError
+
+
+if win32serviceutil is not None:  # pragma: no cover
+    class AgenticHarnessService(AgenticHarnessServiceBase, win32serviceutil.ServiceFramework):
+        """Concrete Windows service implementation."""
+
+        def build_harness(self) -> AgenticHarness:
+            config = AgenticHarnessConfig(
+                planning_document=Path("docs/agentic_harness_plan.yaml"),
+                reference_document=Path("docs/agentic_harness_reference.md"),
+            )
+            planning = PlanningDocument(config.planning_document)
+            reference = ReferenceDocument.load(config.reference_document)
+            claude = ClaudeCodeInterface()
+            verifier = QtTestVerifier()
+            return AgenticHarness(planning, reference, claude, verifier, config=config)
+
+
+__all__ = [
+    "AgenticHarness",
+    "AgenticHarnessConfig",
+]
+
+
+def main() -> None:  # pragma: no cover - entrypoint for Windows service tooling
+    """Entry-point used for installing/running the Windows service."""
+
+    if win32serviceutil is None:
+        raise RuntimeError("Windows service utilities are not available on this platform")
+    if "AgenticHarnessService" not in globals():
+        raise RuntimeError("AgenticHarnessService is unavailable without pywin32 installed")
+    service_class = globals()["AgenticHarnessService"]
+    win32serviceutil.HandleCommandLine(service_class)  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/tests/services/test_agentic_harness_documents.py
+++ b/tests/services/test_agentic_harness_documents.py
@@ -1,0 +1,93 @@
+"""Unit tests for the agentic harness planning and reference modules."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from talekeeper.services.agentic_harness.claude_interface import ClaudeCodeInterface
+from talekeeper.services.agentic_harness.planning import PlanningDocument, TaskRecord
+from talekeeper.services.agentic_harness.qt_test_verifier import QtTestVerifier
+from talekeeper.services.agentic_harness.reference import ReferenceDocument
+
+
+def test_planning_document_tracks_status(tmp_path: Path) -> None:
+    plan_path = tmp_path / "plan.yaml"
+    document = PlanningDocument(plan_path)
+
+    task = TaskRecord(
+        task_id="example",
+        description="Example task",
+        tests=["tests/sample.py::test_ok"],
+        documentation_targets=["docs/example.md"],
+    )
+    document.update_task(task)
+
+    fetched = document.get_next_task()
+    assert fetched is not None
+    assert fetched.task_id == "example"
+
+    document.mark_status("example", "in_progress", note="started")
+    document.record_failure("example", "Assertion failed", tests=task.tests)
+    document.mark_status("example", "needs_revision")
+    refreshed = PlanningDocument(plan_path)
+    saved_task = refreshed.get_next_task(allowed_statuses=["needs_revision"])
+    assert saved_task is not None
+    assert saved_task.retries == 1
+    assert saved_task.subtasks, "Failure should have created a remediation subtask"
+
+    document.record_success("example", "All tests passed")
+    completed = document.get_next_task(allowed_statuses=["completed"])
+    assert completed is not None
+    assert completed.status == "completed"
+    assert completed.last_success_at is not None
+
+    document.record_pause("manual stop")
+    stored = document.to_dict()
+    assert stored["pauses"], "Pause entries should be recorded"
+
+
+def test_reference_document_parses_sections(tmp_path: Path) -> None:
+    reference_path = tmp_path / "reference.md"
+    reference_path.write_text(
+        """# Reference\n\n## Objective\nDo the thing.\n\n## Acceptance Criteria\n- first\n- second\n\n## Required Qt6 Tests\n- a\n- b\n""",
+        encoding="utf-8",
+    )
+    reference = ReferenceDocument.load(reference_path)
+    assert reference.final_objective == "Do the thing."
+    assert reference.acceptance_criteria == ["first", "second"]
+    assert reference.required_tests == ["a", "b"]
+
+
+def test_claude_interface_writes_inbox(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    inbox_path = tmp_path / "inbox.json"
+    monkeypatch.setenv("CLAUDE_CODE_INBOX", str(inbox_path))
+    interface = ClaudeCodeInterface(inbox_path=inbox_path)
+    task = TaskRecord(task_id="t1", description="Example", tests=[], documentation_targets=[])
+    result = interface.send_task(task, context={"demo": True})
+    assert result.payload_path == inbox_path
+    payload = json.loads(inbox_path.read_text(encoding="utf-8"))
+    assert payload["task"]["id"] == "t1"
+    assert payload["context"]["demo"] is True
+
+
+def test_qt_test_verifier_runs_pytest(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_example.py"
+    test_file.write_text(
+        """def test_ok():\n    assert True\n""",
+        encoding="utf-8",
+    )
+    verifier = QtTestVerifier(working_directory=tmp_path)
+    result = verifier.run_tests([str(test_file)])
+    assert result.success
+    assert "1 passed" in result.output
+
+


### PR DESCRIPTION
## Summary
- add an agentic harness orchestration layer and Windows service wrapper that coordinates Claude Code tasks and Qt6 verification
- author planning, reference, and service operation documents to guide the harness workflow
- extend the test suite for the planning/reference utilities and add PyYAML as a core dependency

## Testing
- pytest tests/services/test_agentic_harness_documents.py

------
https://chatgpt.com/codex/tasks/task_e_68e62888479c832bbed5658b2e180a5e