### PR TITLE
Research familiar mechanics in Talekeeper game

### DIFF
--- a/src/talekeeper/ui/action_cards/action_panel.py
+++ b/src/talekeeper/ui/action_cards/action_panel.py
@@ -8804,6 +8804,8 @@ class ActionPanel(QWidget):
                     break
                 parent = parent.parent()
 
+            # Check for familiar summoning (Pact of the Chain)
+            self._check_familiar_summoning()
 
         except Exception as e:
             print(f"Error during long rest: {e}")


### PR DESCRIPTION
- Familiar selection dialog now appears after both short and long rest
- Previously only appeared after short rest
- Warlocks with Pact of the Chain can now choose their familiar after any rest if not already selected